### PR TITLE
Add Winget output to log file

### DIFF
--- a/Winget-AutoUpdate/winget-upgrade.ps1
+++ b/Winget-AutoUpdate/winget-upgrade.ps1
@@ -269,7 +269,7 @@ if (Test-Network){
 
             #Winget upgrade
             Write-Log "------ Winget - $($app.Name) Upgrade Starts ------" "Gray"
-            & $upgradecmd upgrade --id $($app.Id) --all --accept-package-agreements --accept-source-agreements -h
+            & $upgradecmd upgrade --id $($app.Id) --all --accept-package-agreements --accept-source-agreements -h | Tee-Object -file $LogFile -Append
             Write-Log "----- Winget - $($app.Name) Upgrade Finished -----" "Gray"   
 
             #Check installed version


### PR DESCRIPTION
For better troubleshoot, the Winget command output is now saved in the log file.

As mentioned here https://github.com/Romanitho/Winget-AutoUpdate/issues/6#issuecomment-1046730122 by @leochras 
