### PR TITLE
Added Azure Blob Storage for 'Mods'

### DIFF
--- a/Policies/WAU.admx
+++ b/Policies/WAU.admx
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="4.7" xsi:schemaLocation="" schemaVersion="1.0" xmlns="http://www.microsoft.com/GroupPolicy/PolicyDefinitions">
+<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="4.8" xsi:schemaLocation="" schemaVersion="1.0" xmlns="http://www.microsoft.com/GroupPolicy/PolicyDefinitions">
   <policyNamespaces>
     <target prefix="WAU" namespace="Romanitho.Policies.WAU"/>
   </policyNamespaces>
-  <resources minRequiredRevision="4.7" fallbackCulture="en-us"/>
+  <resources minRequiredRevision="4.8" fallbackCulture="en-us"/>
   <supportedOn>
     <definitions>
       <definition name="SUPPORTED_WAU_1_16_0" displayName="$(string.SUPPORTED_WAU_1_16_0)"/>
+      <definition name="SUPPORTED_WAU_1_16_5" displayName="$(string.SUPPORTED_WAU_1_16_5)"/>
     </definitions>
   </supportedOn>
   <categories><category displayName="$(string.WAU)" name="WAU"/></categories>
@@ -97,6 +98,13 @@
       <supportedOn ref="WAU:SUPPORTED_WAU_1_16_0"/>
       <elements>
         <text id="ModsPath" valueName="WAU_ModsPath" />
+      </elements>
+    </policy>
+    <policy name="BlobURL_Enable" class="Machine" displayName="$(string.BlobURL_Name)" explainText="$(string.BlobURL_Explain)" key="Software\Policies\Romanitho\Winget-AutoUpdate" presentation="$(presentation.BlobURL)" >
+      <parentCategory ref="WAU"/>
+      <supportedOn ref="WAU:SUPPORTED_WAU_1_16_5"/>
+      <elements>
+        <text id="BlobURL" valueName="WAU_AzureBlobSASURL" />
       </elements>
     </policy>
     <policy name="NotificationLevel_Enable" class="Machine" displayName="$(string.NotificationLevel_Name)" explainText="$(string.NotificationLevel_Explain)" key="Software\Policies\Romanitho\Winget-AutoUpdate"  presentation="$(presentation.NotificationLevel)">

--- a/Policies/en-US/WAU.adml
+++ b/Policies/en-US/WAU.adml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="4.7" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="4.8" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <displayName>WinGet-AutoUpdate</displayName>
   <description>WinGet-AutoUpdate GPO Management</description>
   <resources >
     <stringTable >
       <string id="WAU">Winget-AutoUpdate</string>
       <string id="SUPPORTED_WAU_1_16_0">Winget-AutoUpdate version 1.16.0 or later</string>
+      <string id="SUPPORTED_WAU_1_16_5">Winget-AutoUpdate version 1.16.5 or later</string>
       <string id="ActivateGPOManagement_Name">Activate WAU GPO Management</string>
       <string id="ActivateGPOManagement_Explain">This policy setting is an overriding toggle for GPO Management of Winget-AutoUpdate.</string>
       <string id="BypassListForUsers_Name">Bypass Black/White list for User</string>
@@ -43,10 +44,16 @@ If this policy is disabled or not configured, the default is No.</string>
 If "Application GPO Blacklist/Whitelist" is set in this GPO the Path can be: GPO
 
 If this policy is disabled or not configured, the default ListPath is used (WAU InstallLocation).</string>
-      <string id="ModsPath_Name">Get Mods from external Path (URL/UNC/Local)</string>
-      <string id="ModsPath_Explain">If this policy is enabled, you can set a (URL/UNC/Local) Path to external mods other than the default.
+      <string id="ModsPath_Name">Get Mods from external Path (URL/UNC/Local/AzureBlob)</string>
+      <string id="ModsPath_Explain">If this policy is enabled, you can set a (URL/UNC/Local/AzureBlob) Path to external mods other than the default. 
       
-If this policy is disabled or not configured, the default ModsPath is used (WAU InstallLocation).</string>
+If this policy is disabled or not configured, the default ModsPath is used (WAU InstallLocation).
+
+Note: When set to 'AzureBlob', ensure you also configure 'Set Azure Blob URL with SAS token'.</string>
+      <string id="BlobURL_Name">Set Azure Blob URL with SAS Token</string>
+      <string id="BlobURL_Explain">If this policy is enabled, you can set an Azure Storage Blob URL with SAS token for use with the 'Mods' feature. The URL must include the SAS token and have 'read' and 'list' permissions.
+
+If this policy is disabled or not configured, the value is blank and Azure Blob storage will NOT work.</string>
       <string id="NotificationLevel_Name">Notification Level</string>
       <string id="NotificationLevel_Explain">If this policy is enabled, you can configure the Notification Level:
 1. Full (Default)
@@ -148,8 +155,13 @@ If this policy is disabled or not configured, the default size is used.</string>
       </presentation>
       <presentation id="ModsPath">
         <textBox refId="ModsPath">
-          <label>(URL/UNC/Local) Path:</label>
+          <label>(URL/UNC/Local/AzureBlob) Path:</label>
         </textBox>
+      </presentation>  
+      <presentation id="BlobURL">
+            <textBox refId="BlobURL">
+                  <label>Azure Storage URL with SAS token:</label>
+            </textBox>
       </presentation>
       <presentation id="NotificationLevel">
         <dropdownList refId="NotificationLevel"/>

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ If `-ListPath` is set to **GPO** the Black/White List can be managed from within
 Thanks to [Weatherlights](https://github.com/Weatherlights) in [#256 (reply in thread)](https://github.com/Romanitho/Winget-AutoUpdate/discussions/256#discussioncomment-4710599)!
 
 **-ModsPath**  
-Get Mods from external Path (**URL/UNC/Local**) - download/copy to `mods` in Winget-AutoUpdate installation location if external mods are newer.  
+Get Mods from external Path (**URL/UNC/Local/AzureBlob**) - download/copy to `mods` in Winget-AutoUpdate installation location if external mods are newer.  
 
 For **URL**: This requires a site directory with **Directory Listing Enabled** and no index page overriding the listing of files (or an index page with href listing of all the **Mods** to be downloaded):  
 ```
@@ -120,6 +120,11 @@ Validated on **IIS/Apache**.
 **Nota bene IIS** :  
  - The extension **.ps1** must be added as **MIME Types** (text/powershell-script) otherwise it's displayed in the listing but can't be opened
  - Files with special characters in the filename can't be opened by default from an IIS server - config must be administrated: **Enable Allow double escaping** in '**Request Filtering**'
+
+For **AzureBlob**: This requires the parameter **-AzureBlobURL** to be set with an appropriate Azure Blob Storage URL including the SAS token. See **-AzureBlobURL** for more information.
+
+**-AzureBlobURL**
+Used in conjunction with the **-ModsPath** parameter to provide the Azure Storage Blob URL with SAS token. The SAS token must, at a minimum, have 'Read' and 'List' permissions. It is recommended to set the permisions at the container level and rotate the SAS token on a regular basis. Ensure the container reflects the same structure as found under the initial `mods` folder. (From version 1.16.4).
 
 **-InstallUserContext**  
 Install WAU with system and **user** context executions (From version 1.15.3).

--- a/Winget-AutoUpdate-Install.ps1
+++ b/Winget-AutoUpdate-Install.ps1
@@ -29,10 +29,13 @@ Disable Winget-AutoUpdate update checking. By default, WAU auto update if new ve
 Use White List instead of Black List. This setting will not create the "exclude_apps.txt" but "include_apps.txt"
 
 .PARAMETER ListPath
-Get Black/White List from Path (URL/UNC/Local)
+Get Black/White List from Path (URL/UNC/GPO/Local)
 
 .PARAMETER ModsPath
-Get mods from Path (URL/UNC/Local)
+Get mods from Path (URL/UNC/Local/AzureBlob)
+
+.PARAMETER AzureBlobURL
+Set the Azure Storage Blob URL including the SAS token. The token requires at a minimum 'Read' and 'List' permissions. It is recommended to set this at the container level
 
 .PARAMETER Uninstall
 Remove scheduled tasks and scripts.
@@ -93,6 +96,7 @@ param(
     [Parameter(Mandatory = $False)] [Alias('Path')] [String] $WingetUpdatePath = "$env:ProgramData\Winget-AutoUpdate",
     [Parameter(Mandatory = $False)] [Alias('List')] [String] $ListPath,
     [Parameter(Mandatory = $False)] [Alias('Mods')] [String] $ModsPath,
+    [Parameter(Mandatory = $False)] [Alias('AzureBlobURL')] [String] $AzureBlobSASURL,
     [Parameter(Mandatory = $False)] [Switch] $DoNotUpdate = $false,
     [Parameter(Mandatory = $False)] [Switch] $DisableWAUAutoUpdate = $false,
     [Parameter(Mandatory = $False)] [Switch] $RunOnMetered = $false,
@@ -113,7 +117,7 @@ param(
 
 <# APP INFO #>
 
-$WAUVersion = "1.16.4"
+$WAUVersion = "1.16.5"
 
 <# FUNCTIONS #>
 
@@ -362,6 +366,9 @@ function Install-WingetAutoUpdate {
         }
         if ($ModsPath) {
             New-ItemProperty $regPath -Name WAU_ModsPath -Value $ModsPath -Force | Out-Null
+        }
+        if ($AzureBlobSASURL) {
+            New-ItemProperty $regPath -Name WAU_AzureBlobSASURL -Value $AzureBlobSASURL -Force | Out-Null
         }
         if ($BypassListForUsers) {
             New-ItemProperty $regPath -Name WAU_BypassListForUsers -Value 1 -PropertyType DWord -Force | Out-Null

--- a/Winget-AutoUpdate/Winget-Upgrade.ps1
+++ b/Winget-AutoUpdate/Winget-Upgrade.ps1
@@ -87,7 +87,7 @@ if (Test-Network) {
             $WAUDisableAutoUpdate = $WAUConfig.WAU_DisableAutoUpdate
             #If yes then check WAU update if run as System
             if ($WAUDisableAutoUpdate -eq 1) {
-                Write-Log "WAU AutoUpdate is Disabled." "Grey"
+                Write-Log "WAU AutoUpdate is Disabled." "Gray"
             }
             else {
                 Write-Log "WAU AutoUpdate is Enabled." "Green"
@@ -152,7 +152,7 @@ if (Test-Network) {
             if ($WAUConfig.WAU_ModsPath) {
                 $ModsPathClean = $($WAUConfig.WAU_ModsPath.TrimEnd(" ", "\", "/"))
                 Write-Log "WAU uses External Mods from: $ModsPathClean"
-                $NewMods, $DeletedMods = Test-ModsPath $ModsPathClean $WAUConfig.InstallLocation.TrimEnd(" ", "\")
+                $NewMods, $DeletedMods = Test-ModsPath $ModsPathClean $WAUConfig.InstallLocation.TrimEnd(" ", "\") $WAUConfig.WAU_AzureBlobSASURL.TrimEnd(" ")
                 if ($ReachNoPath) {
                     Write-Log "Couldn't reach/find/compare/copy from $ModsPathClean..." "Red"
                     $Script:ReachNoPath = $False

--- a/Winget-AutoUpdate/functions/Get-AZCopy.ps1
+++ b/Winget-AutoUpdate/functions/Get-AZCopy.ps1
@@ -1,0 +1,50 @@
+#Function to get AZCopy if it doesn't exist and update it if it does
+
+Function Get-AZCopy ($WingetUpdatePath){
+
+    $AZCopyLink = (Invoke-WebRequest -Uri https://aka.ms/downloadazcopy-v10-windows -MaximumRedirection 0 -ErrorAction SilentlyContinue).headers.location
+    $AZCopyVersionRegex = [regex]::new("(\d+\.\d+\.\d+)")
+    $AZCopyLatestVersion = $AZCopyVersionRegex.Match($AZCopyLink).Value
+
+    if ($null -eq $AZCopyLatestVersion -or "" -eq $AZCopyLatestVersion) {
+        $AZCopyLatestVersion = "0.0.0"
+    }
+
+    if (Test-Path -Path "$WingetUpdatePath\azcopy.exe" -PathType Leaf) {
+        $AZCopyCurrentVersion = & "$WingetUpdatePath\azcopy.exe" -v
+        $AZCopyCurrentVersion = $AZCopyVersionRegex.Match($AZCopyCurrentVersion).Value 
+        Write-Log  "AZCopy version $AZCopyCurrentVersion found" 
+    }
+    else {
+        Write-Log  "AZCopy not already installed" 
+        $AZCopyCurrentVersion = "0.0.0"
+    }
+
+    if (([version] $AZCopyCurrentVersion) -lt ([version] $AZCopyLatestVersion)) {
+        Write-Log  "Installing version $AZCopyLatestVersion of AZCopy"   
+        Invoke-WebRequest -Uri $AZCopyLink -OutFile "$WingetUpdatePath\azcopyv10.zip"
+        Write-Log  "Extracting AZCopy zip file"
+
+        Expand-archive -Path "$WingetUpdatePath\azcopyv10.zip" -Destinationpath "$WingetUpdatePath" -Force
+
+        $AZCopyPathSearch = Resolve-Path -path "$WingetUpdatePath\azcopy_*" 
+    
+        if ($AZCopyPathSearch -is [array]) {
+            $AZCopyEXEPath = $AZCopyPathSearch[$AZCopyPathSearch.Length - 1]
+        }
+        else {
+            $AZCopyEXEPath = $AZCopyPathSearch
+        }
+
+        Write-Log  "Copying 'azcopy.exe' to main folder"
+        Copy-Item "$AZCopyEXEPath\azcopy.exe" -Destination "$WingetUpdatePath\"
+
+        Write-Log  "Removing temporary AZCopy files"
+        Remove-Item -Path $AZCopyEXEPath -Recurse
+        Remove-Item -Path "$WingetUpdatePath\azcopyv10.zip"
+
+        $AZCopyCurrentVersion = & "$WingetUpdatePath\azcopy.exe" -v
+        $AZCopyCurrentVersion = $AZCopyVersionRegex.Match($AZCopyCurrentVersion).Value
+        Write-Log  "AZCopy version $AZCopyCurrentVersion installed"
+    }
+}

--- a/Winget-AutoUpdate/functions/Get-Policies.ps1
+++ b/Winget-AutoUpdate/functions/Get-Policies.ps1
@@ -69,6 +69,14 @@ Function Get-Policies {
                 Remove-ItemProperty $regPath -Name WAU_ModsPath -Force -ErrorAction SilentlyContinue | Out-Null
                 $ChangedSettings++
             }
+            if ($null -ne $($WAUPolicies.WAU_AzureBlobSASURL) -and ($($WAUPolicies.WAU_AzureBlobSASURL) -ne $($WAUConfig.WAU_AzureBlobSASURL))) {
+                New-ItemProperty $regPath -Name WAU_AzureBlobSASURL -Value $($WAUPolicies.WAU_AzureBlobSASURL.TrimEnd(" ", "\", "/")) -Force | Out-Null
+                $ChangedSettings++
+            }
+            elseif ($null -eq $($WAUPolicies.WAU_AzureBlobSASURL) -and $($WAUConfig.WAU_AzureBlobSASURL)) {
+                Remove-ItemProperty $regPath -Name WAU_AzureBlobSASURL -Force -ErrorAction SilentlyContinue | Out-Null
+                $ChangedSettings++
+            }
 
             if ($null -ne $($WAUPolicies.WAU_NotificationLevel) -and ($($WAUPolicies.WAU_NotificationLevel) -ne $($WAUConfig.WAU_NotificationLevel))) {
                 New-ItemProperty $regPath -Name WAU_NotificationLevel -Value $($WAUPolicies.WAU_NotificationLevel) -Force | Out-Null


### PR DESCRIPTION
# Proposed Changes

Currently 'Mods' have to be local, on a more traditional local server file share or an http web server. Unfortunately, none of those options worked for my client, as they are cloud first and didn't want to run a web server just to host mod files. So, I have added the ability to use Azure Blob Storage to host 'Mods'. The functionality has been added in a way to maintain backwards compatibility with the other 'Mods' options.

I have incremented the version to 1.16.5. Not sure if that is okay, but i needed to increase it to something for the ADMX files to reference when this feature was added.
