### PR TITLE
Check actual language instead of region

### DIFF
--- a/Winget-AutoUpdate/functions/Get-NotifLocale.ps1
+++ b/Winget-AutoUpdate/functions/Get-NotifLocale.ps1
@@ -3,7 +3,7 @@
 Function Get-NotifLocale {
 
     #Get OS locale
-    $OSLocale = (Get-Culture).Parent
+    $OSLocale = (Get-UICulture).Parent
 
     #Test if OS locale notif file exists
     $TestOSLocalPath = "$WorkingDir\locale\$($OSLocale.Name).xml"


### PR DESCRIPTION
"Get-Culture" returns system region, while "Get-UICulture" returns the actual Windows display language.

# Proposed Changes

> I'm from Italy, and WAU generates notifications in Italian, even though my display language is set to US English, because my region is set to Italy. On my system, `Get-Culture` returns Italian, while `Get-UICulture` correctly reports US English, so I propose using the latter.

## Related Issues

> #298 
