### PR TITLE
Switch Megatlinter Workflow to oxsecurity/megalinter

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -41,7 +41,7 @@ jobs:
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.github.io/flavors/
-        uses: megalinter/megalinter@v6
+        uses: oxsecurity/megalinter@v6
         env:
           # All available variables are described in documentation
           # https://megalinter.github.io/configuration/


### PR DESCRIPTION
# Proposed Changes
Megalinter has changed its repository owner and therefore the action name. 
https://github.com/oxsecurity/megalinter/issues/2497#issuecomment-1490831917

This commit prepares the workflow to continue to work,a fter the old repository link will be made unavailable.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
