### PR TITLE
Symlink install.log to Intune Log folder

### DIFF
--- a/Winget-AutoUpdate/functions/Start-Init.ps1
+++ b/Winget-AutoUpdate/functions/Start-Init.ps1
@@ -44,9 +44,9 @@ function Start-Init {
     }
 
     #Check if Intune Management Extension Logs folder and WAU-updates.log exists, make symlink
-    if ((Test-Path "${env:ProgramData}\Microsoft\IntuneManagementExtension\Logs") -and !(Test-Path "${env:ProgramData}\Microsoft\IntuneManagementExtension\Logs\WAU-updates.log")) {
+    if ((Test-Path "${env:ProgramData}\Microsoft\IntuneManagementExtension\Logs") -and !(Test-Path "${env:ProgramData}\Microsoft\IntuneManagementExtension\Logs\WAU-Logs")) {
         Write-host "`nCreating SymLink for log file in Intune Management Extension log folder" -ForegroundColor Yellow
-        New-Item -Path "${env:ProgramData}\Microsoft\IntuneManagementExtension\Logs\WAU-updates.log" -ItemType SymbolicLink -Value $LogFile -Force -ErrorAction SilentlyContinue | Out-Null
+        New-Item -Path "${env:ProgramData}\Microsoft\IntuneManagementExtension\Logs\WAU-Logs" -ItemType SymbolicLink -Value "$WingetUpdatePath\logs" -Force -ErrorAction SilentlyContinue | Out-Null
     }
 
 

--- a/Winget-AutoUpdate/functions/Start-Init.ps1
+++ b/Winget-AutoUpdate/functions/Start-Init.ps1
@@ -44,12 +44,15 @@ function Start-Init {
     }
 
     #Check if Intune Management Extension Logs folder and WAU-updates.log exists, make symlink
-    if ((Test-Path "${env:ProgramData}\Microsoft\IntuneManagementExtension\Logs") -and !(Test-Path "${env:ProgramData}\Microsoft\IntuneManagementExtension\Logs\WAU-Logs")) {
-        Write-host "`nCreating SymLink for log file in Intune Management Extension log folder" -ForegroundColor Yellow
-        New-Item -Path "${env:ProgramData}\Microsoft\IntuneManagementExtension\Logs\WAU-Logs" -ItemType SymbolicLink -Value "$WingetUpdatePath\logs" -Force -ErrorAction SilentlyContinue | Out-Null
+    if ((Test-Path "${env:ProgramData}\Microsoft\IntuneManagementExtension\Logs") -and !(Test-Path "${env:ProgramData}\Microsoft\IntuneManagementExtension\Logs\WAU-updates.log")) {
+        Write-host "`nCreating SymLink for log file (WAU-updates) in Intune Management Extension log folder" -ForegroundColor Yellow
+        New-Item -Path "${env:ProgramData}\Microsoft\IntuneManagementExtension\Logs\WAU-updates.log" -ItemType SymbolicLink -Value $LogFile -Force -ErrorAction SilentlyContinue | Out-Null
     }
-
-
+    if ((Test-Path "${env:ProgramData}\Microsoft\IntuneManagementExtension\Logs") -and !(Test-Path "${env:ProgramData}\Microsoft\IntuneManagementExtension\Logs\WAU-install.log")) {
+        Write-host "`nCreating SymLink for log file (WAU-install) in Intune Management Extension log folder" -ForegroundColor Yellow
+        New-Item -Path "${env:ProgramData}\Microsoft\IntuneManagementExtension\Logs\WAU-install.log" -ItemType SymbolicLink -Value "$WorkingDir\logs\install.log" -Force -ErrorAction SilentlyContinue | Out-Null
+    }
+    
     if ($caller -eq "Winget-Upgrade.ps1") {
         #Log file
         $Log | out-file -filepath $LogFile -Append


### PR DESCRIPTION
# Proposed Changes

Currently only the WAU update log is being symlinked to the Intune folder. I would prefer to symlink the full WAU log folder, so that install/uninstall Logs from winget-install.ps1 are available through Intune too.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
