### PR TITLE
Activate pre-release updates on pre-release install

### DIFF
--- a/Winget-AutoUpdate-Install.ps1
+++ b/Winget-AutoUpdate-Install.ps1
@@ -343,7 +343,12 @@ function Install-WingetAutoUpdate {
         New-ItemProperty $regPath -Name Publisher -Value "Romanitho" -Force | Out-Null
         New-ItemProperty $regPath -Name URLInfoAbout -Value "https://github.com/Romanitho/Winget-AutoUpdate" -Force | Out-Null
         New-ItemProperty $regPath -Name WAU_NotificationLevel -Value $NotificationLevel -Force | Out-Null
-        New-ItemProperty $regPath -Name WAU_UpdatePrerelease -Value 0 -PropertyType DWord -Force | Out-Null
+        if ($WAUVersion -match "-"){
+            New-ItemProperty $regPath -Name WAU_UpdatePrerelease -Value 1 -PropertyType DWord -Force | Out-Null
+        }
+        else {
+            New-ItemProperty $regPath -Name WAU_UpdatePrerelease -Value 0 -PropertyType DWord -Force | Out-Null
+        }
         New-ItemProperty $regPath -Name WAU_PostUpdateActions -Value 0 -PropertyType DWord -Force | Out-Null
         New-ItemProperty $regPath -Name WAU_MaxLogFiles -Value $MaxLogFiles -PropertyType DWord -Force | Out-Null
         New-ItemProperty $regPath -Name WAU_MaxLogSize -Value $MaxLogSize -PropertyType DWord -Force | Out-Null


### PR DESCRIPTION
# Proposed Changes

> When a pre-release version is installed it will update to latest stable version if WAU self update is enabled. To prevent this, if a pre-release version is installed, it enables WAU self updates to pre-release versions too.

## Related Issues

> none
