### PR TITLE
Changed to Get-CimInstance where it can be done

### DIFF
--- a/Winget-AutoUpdate/Winget-Upgrade.ps1
+++ b/Winget-AutoUpdate/Winget-Upgrade.ps1
@@ -20,7 +20,7 @@ $LogFile = "$WorkingDir\logs\updates.log"
 
 if ($IsSystem) {
     #Check if any connected user when running as system
-    $explorerprocesses = @(Get-WmiObject -Query "Select * FROM Win32_Process WHERE Name='explorer.exe'" -ErrorAction SilentlyContinue)
+    $explorerprocesses = @(Get-CimInstance -Query "SELECT * FROM Win32_Process WHERE Name='explorer.exe'" -ErrorAction SilentlyContinue)
     #Check if ServiceUI exists
     $ServiceUI = Test-Path "$WorkingDir\ServiceUI.exe"
     If ($explorerprocesses.Count -gt 0 -and $ServiceUI) {
@@ -349,8 +349,7 @@ if (Test-Network) {
                     $UserContextTask = Get-ScheduledTask -TaskName 'Winget-AutoUpdate-UserContext' -ErrorAction SilentlyContinue
                 }
 
-                #User check routine from: https://stackoverflow.com/questions/23219718/powershell-script-to-see-currently-logged-in-users-domain-and-machine-status
-                $explorerprocesses = @(Get-WmiObject -Query "Select * FROM Win32_Process WHERE Name='explorer.exe'" -ErrorAction SilentlyContinue)
+                $explorerprocesses = @(Get-CimInstance -Query "SELECT * FROM Win32_Process WHERE Name='explorer.exe'" -ErrorAction SilentlyContinue)
                 If ($explorerprocesses.Count -eq 0) {
                     Write-ToLog "No explorer process found / Nobody interactively logged on..."
                 }

--- a/Winget-AutoUpdate/functions/Test-PendingReboot.ps1
+++ b/Winget-AutoUpdate/functions/Test-PendingReboot.ps1
@@ -12,7 +12,7 @@ function Test-PendingReboot {
         if (($WMI_Reg.EnumKey($HKLM, "SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\")).sNames -contains 'RebootPending') { $PendingReboot = $true }
         if (($WMI_Reg.EnumKey($HKLM, "SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\")).sNames -contains 'RebootRequired') { $PendingReboot = $true }
 
-        #Checking for SCCM namespace
+        #Checking for SCCM namespace (can't get it done with Get-CimInstance, using deprecated Get-WmiObject)
         $SCCM_Namespace = Get-WmiObject -Namespace ROOT\CCM\ClientSDK -List -ComputerName $Computer -ErrorAction Ignore
         if ($SCCM_Namespace) {
             if (([WmiClass]"\\$Computer\ROOT\CCM\ClientSDK:CCM_ClientUtilities").DetermineIfRebootPending().RebootPending -eq $true) { $PendingReboot = $true }

--- a/Winget-AutoUpdate/functions/Update-StoreApps.ps1
+++ b/Winget-AutoUpdate/functions/Update-StoreApps.ps1
@@ -11,6 +11,7 @@ Function Update-StoreApps {
 		Write-ToLog $force_string "yellow"
 
 		try {
+			# Can't get it done with Get-CimInstance, using deprecated Get-WmiObject
 			$namespaceName = "root\cimv2\mdm\dmmap"
 			$className = "MDM_EnterpriseModernAppManagement_AppManagement01"
 			$wmiObj = Get-WmiObject -Namespace $namespaceName -Class $className


### PR DESCRIPTION
# Proposed Changes
Get-WMIObject is deprecated in windows PowerShell and has been removed from PowerShell Core, so the general recommendation is to go with CIM
