### PR TITLE
Stop running Get-Command Under User

### DIFF
--- a/Winget-AutoUpdate/functions/Get-WingetCmd.ps1
+++ b/Winget-AutoUpdate/functions/Get-WingetCmd.ps1
@@ -18,9 +18,8 @@ Function Get-WingetCmd {
         }
     }else{
         #Get Winget Location in User context
-        $WingetCmd = Get-Command winget.exe -ErrorAction SilentlyContinue
-        if ($WingetCmd) {
-            $Script:Winget = $WingetCmd.Source
+        if (Test-Path "$env:LocalAppData\Microsoft\WindowsApps\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\winget.exe") {
+            $Script:Winget = "$env:LocalAppData\Microsoft\WindowsApps\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\winget.exe"
         }
     }
 


### PR DESCRIPTION
`Get-Command winget.exe` not always returns the path to winget when in user context. When running in user context I received on a Win11 machine the same error as here: https://github.com/Romanitho/Winget-AutoUpdate/issues/387#issuecomment-1710604158

# Proposed Changes

Since winget is installed to a predefined path (similar to system context installation of winget as introduced in https://github.com/Romanitho/Winget-AutoUpdate/pull/389), let's just reference that one.

**Note:** Successfully tested on 2 Windows 11 machines only. Might require some testing before merging to production.

## Related Issues
https://github.com/Romanitho/Winget-AutoUpdate/issues/387