### PR TITLE
Fix network test failing

### DIFF
--- a/Winget-AutoUpdate/functions/Test-Network.ps1
+++ b/Winget-AutoUpdate/functions/Test-Network.ps1
@@ -9,10 +9,10 @@ function Test-Network {
     Write-ToLog "Checking internet connection..." "Yellow"
     While ($timeout -lt 1800) {
 
-        $URLtoTest = "https://raw.githubusercontent.com/Romanitho/Winget-AutoUpdate/main/LICENSE"
-        $URLcontent = ((Invoke-WebRequest -URI $URLtoTest -UseBasicParsing).content)
+        $URLtoTest = "https://github.com/Romanitho/Winget-AutoUpdate"
+        $UrlStatusCode = ((Invoke-WebRequest -URI $URLtoTest -UseBasicParsing).StatusCode)
 
-        if ($URLcontent -like "*MIT License*") {
+        if ($UrlStatusCode -eq "200"){
 
             Write-ToLog "Connected !" "Green"
 


### PR DESCRIPTION
# Proposed Changes

> Network connection failing when used the provided link on some systems. Changed link in Test-Network.ps1  to repo main page and checked for status code for validation

![image](https://github.com/Romanitho/Winget-AutoUpdate/assets/118661060/c29729cb-54ba-4555-8b90-a31774a53965)

