### PR TITLE
API Rate limite workarround

### DIFF
--- a/Winget-AutoUpdate/functions/Get-WAUAvailableVersion.ps1
+++ b/Winget-AutoUpdate/functions/Get-WAUAvailableVersion.ps1
@@ -8,18 +8,34 @@ function Get-WAUAvailableVersion {
         #Log
         Write-ToLog "WAU AutoUpdate Pre-release versions is Enabled" "Cyan"
 
-        #Get latest pre-release info
-        $WAUurl = 'https://api.github.com/repos/Romanitho/Winget-AutoUpdate/releases'
+        try {
+            #Get latest pre-release info
+            $WAUurl = 'https://api.github.com/repos/Romanitho/Winget-AutoUpdate/releases'
+            $WAUAvailableVersion = ((Invoke-WebRequest $WAUurl -UseBasicParsing | ConvertFrom-Json)[0].tag_name).Replace("v", "")
+        }
+        catch {
+            $url = "https://github.com/Romanitho/Winget-AutoUpdate/releases"
+            $link = ((Invoke-WebRequest $url -UseBasicParsing).Links.href -match "/Winget-AutoUpdate/releases/tag/v*")[0]
+            $WAUAvailableVersion = $link.Trim().Split("v")[-1]
+        }
 
     }
     else {
 
-        #Get latest stable info
-        $WAUurl = 'https://api.github.com/repos/Romanitho/Winget-AutoUpdate/releases/latest'
+        try {
+            #Get latest stable info
+            $WAUurl = 'https://api.github.com/repos/Romanitho/Winget-AutoUpdate/releases/latest'
+            $WAUAvailableVersion = ((Invoke-WebRequest $WAUurl -UseBasicParsing | ConvertFrom-Json)[0].tag_name).Replace("v", "")
+        }
+        catch {
+            $url = "https://github.com/Romanitho/Winget-AutoUpdate/releases/latest"
+            $link = ((Invoke-WebRequest $url -UseBasicParsing).Links.href -match "/Winget-AutoUpdate/releases/tag/v*")[0]
+            $WAUAvailableVersion = $link.Trim().Split("v")[-1]
+        }
 
     }
 
     #Return version
-    return ((Invoke-WebRequest $WAUurl -UseBasicParsing | ConvertFrom-Json)[0].tag_name).Replace("v", "")
+    return $WAUAvailableVersion
 
 }


### PR DESCRIPTION
# Proposed Changes

This change adds a workaround to the actual `60 requests per hour` rate limite
https://docs.github.com/en/github-ae@latest/rest/overview/rate-limits-for-the-rest-api#primary-rate-limit-for-unauthenticated-users