### PR TITLE
Update Add-ScopeMachine.ps1

### DIFF
--- a/Winget-AutoUpdate/functions/Add-ScopeMachine.ps1
+++ b/Winget-AutoUpdate/functions/Add-ScopeMachine.ps1
@@ -15,6 +15,6 @@ function Add-ScopeMachine ($SettingsPath) {
         $Preference = New-Object PSObject -Property $(@{preferences = $Scope })
         Add-Member -InputObject $ConfigFile -MemberType NoteProperty -Name 'installBehavior' -Value $Preference -Force
     }
-    $ConfigFile | ConvertTo-Json | Out-File $SettingsPath -Encoding utf8 -Force
+    $ConfigFile | ConvertTo-Json  -Depth 100 | Out-File $SettingsPath -Encoding utf8 -Force
 
 }


### PR DESCRIPTION
There is a bug which breaks more complex configurations in userSettingsFile (C:\WINDOWS\system32\config\systemprofile\AppData\Local\Microsoft\WinGet\Settings\defaultState\settings.json)

# Proposed Changes

> defining max depth in ConvertTo-json, without it function **Add-ScopeMachine** breaks winget.

## Related Issues

**ConvertTo-Json** has **depth** parameter that controls how many levels of contained objects are included in the JSON representation. The default value is 2. 
ConvertTo-Json will call .ToString() on anything nested deeper than specified depth therefore multiple entries are cast to single string.

F.ex. [architectures](https://github.com/microsoft/winget-cli/blob/master/doc/Settings.md#architectures)
`    "installBehavior": {
        "preferences": {
            "architectures": ["x64", "x86", "neutral"]
        }
    },`
> [ConvertTo-Json](https://technet.microsoft.com/en-us/library/hh849922.aspx) 

resulting state of config file after **Add-ScopeMachine** adds machine scope:
![image](https://github.com/Romanitho/Winget-AutoUpdate/assets/75534654/9c6577c4-064d-4867-bd08-15cd4014f2af)

![image](https://github.com/Romanitho/Winget-AutoUpdate/assets/75534654/46a834dd-6ae1-49f1-a3a2-51d23204e051)
