### PR TITLE
Update Winget-Upgrade.ps1

### DIFF
--- a/Sources/WAU/Winget-AutoUpdate/Winget-Upgrade.ps1
+++ b/Sources/WAU/Winget-AutoUpdate/Winget-Upgrade.ps1
@@ -3,7 +3,7 @@
 #Get the Working Dir
 $Script:WorkingDir = $PSScriptRoot
 #Get Functions
-Get-ChildItem "$WorkingDir\functions" | ForEach-Object { . $_.FullName }
+Get-ChildItem "$WorkingDir\functions" -File -Filter "*.ps1" -Depth 0 | ForEach-Object { . $_.FullName }
 
 
 <# MAIN #>


### PR DESCRIPTION
Quick-Fix for bug reported in https://github.com/Romanitho/Winget-AutoUpdate/issues/543

Summary: fine-tuned the function import
https://github.com/Romanitho/Winget-AutoUpdate/blob/56731950422e46de6a0aadf9d94319a57c595068/Sources/WAU/Winget-AutoUpdate/Winget-Upgrade.ps1#L6

# Proposed Changes

With additional parameters we filter/select file items + files with specific extension (*.ps1) 

`Get-ChildItem "$WorkingDir\functions" -File -Filter "*.ps1" -Depth 0 | ForEach-Object { . $_.FullName }`

## Related Issues

#543 
