### PR TITLE
Update Get-IncludedApps.ps1

### DIFF
--- a/Sources/WAU/Winget-AutoUpdate/functions/Get-IncludedApps.ps1
+++ b/Sources/WAU/Winget-AutoUpdate/functions/Get-IncludedApps.ps1
@@ -1,31 +1,72 @@
+#Definition of return object
+class IncludedApp {
+    [string]$Value;
+    [string]$Data;
+    IncludedApp($v, $d) {
+        $this.Value = $v;
+        $this.Data = $d;
+    }
+}
+
 #Function to get the allow List apps
-
 function Get-IncludedApps {
+    $AppIds = [System.Collections.Generic.List[IncludedApp]]::new();
+    $WAU_GPORoot = "HKLM:\SOFTWARE\Policies\Romanitho\Winget-AutoUpdate";
+    #region whitelist in registry
+    if ($GPOList)
+    {
+        $RegPath = "$WAU_GPORoot\WhiteList";
+        if(Test-Path -Path $RegPath)
+        {
+            $RegKey = Get-Item -Path $RegPath;
+            $values = $RegKey.Property
+            $values | 
+            ForEach-Object {
+                $_v = $_;
+                $_d = Get-ItemPropertyValue -Path $RegPath -Name $_
+                $AppIds.Add([IncludedApp]::new($_v, $_d));
+            }
+        }
+        return $AppIDs;
+    }
+    #endregion whitelist in registry
 
-    if ($GPOList) {
-
-        if (Test-Path "HKLM:\SOFTWARE\Policies\Romanitho\Winget-AutoUpdate\WhiteList") {
-
-            $Key = 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Romanitho\Winget-AutoUpdate\WhiteList\'
-
-            $ValueNames = (Get-Item -Path "HKLM:\SOFTWARE\Policies\Romanitho\Winget-AutoUpdate\WhiteList").Property
-
-            foreach ($ValueName in $ValueNames) {
-                $AppIDs = [Microsoft.Win32.Registry]::GetValue($Key, $ValueName, $false)
-                [PSCustomObject]@{
-                    Value = $ValueName
-                    Data  = $AppIDs.Trim()
+    #region whitelist pulled from URI
+    elseif ($URIList) {
+        $RegPath = "$WAU_GPORoot";
+        $RegValueName = 'WAU_URIList';
+        if(Test-Path -Path $RegPath)
+        {
+            $RegKey = Get-Item -Path $RegPath;
+            $WAUURI = $RegKey.GetValue($RegValueName);
+            if($WAUURI -ne $null)
+            {
+                $resp = Invoke-WebRequest -Uri $WAUURI -UseDefaultCredentials;
+                if($resp.BaseResponse.StatusCode -eq [System.Net.HttpStatusCode]::OK)
+                {
+                    $resp.Content.Split([System.Environment]::NewLine, [System.StringSplitOptions]::RemoveEmptyEntries) | 
+                    ForEach-Object {
+                        $AppIds.Add([IncludedApp]::new($AppIds.Count, $_));
+                    }
                 }
             }
-
         }
-        return $AppIDs
-
+        return $AppIDs;
     }
-    elseif (Test-Path "$WorkingDir\included_apps.txt") {
+    #endregion whitelist pulled from URI
 
+    #region whitelist stored in own folder
+    elseif (Test-Path "$WorkingDir\included_apps.txt") 
+    {
         return (Get-Content -Path "$WorkingDir\included_apps.txt").Trim() | Where-Object { $_.length -gt 0 }
 
     }
+    #endregion whitelist stored in own folder
 
+    else
+    #region empty whitelist (we need to return something..)
+    {
+        return [IncludedApp]::new([string]::Empty, [string]::Empty);
+    }
+    #endregion empty whitelist
 }


### PR DESCRIPTION
Expanded logic to allow pulling Whitelist from URI

# Proposed Changes

It was recently brought to our attention that the Get-IncludedApps.ps1 file could provide a whitelist with package IDs from the registry and a locally stored text file, but when the same file was placed in e.g. a text file in the cloud (e.g. "Azure", we were... unable to get it…

To make our life easier, I decided to define a base class that defines the return object for all supported scenarios.
(If you find this necessary, I'm open to suggestions on where to move it.)

## Related Issues

Inspired by #579 I decided to perform a quick test and with correctly configured Azure Storage Container I was able to safely retrieve the same file which I uploaded from local folder.

To make it usable for this test we will need to define another switch "$URIList" which will utilize new section of 'Get-IncludedApps' function.
