### PR TITLE
MegaLinter/devskim - suppression of warnings

### DIFF
--- a/Sources/Winget-AutoUpdate/functions/Test-ModsPath.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Test-ModsPath.ps1
@@ -13,8 +13,8 @@ function Test-ModsPath ($ModsPath, $WingetUpdatePath, $AzureBlobSASURL) {
     # If path is URL
     if ($ExternalMods -like "http*") {
         # ADD TLS 1.2 and TLS 1.1 to list of currently used protocols
-        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
-        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls11
+        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; #DevSkim: ignore DS440020,DS440020 Hard-coded SSL/TLS Protocol 
+        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls11; #DevSkim: ignore DS440020,DS440020 Hard-coded SSL/TLS Protocol
         #Get Index of $ExternalMods (or index page with href listing of all the Mods)
         try {
             $WebResponse = Invoke-WebRequest -Uri $ExternalMods -UseBasicParsing

--- a/Sources/Winget-AutoUpdate/functions/Test-Network.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Test-Network.ps1
@@ -22,7 +22,7 @@ function Test-Network {
 
     While ($timeout -lt 1800) {
         try {
-            $ncsiResponse = Invoke-WebRequest -Uri "http://$($ncsiHost)/$($ncsiPath)" -UseBasicParsing -UserAgent ([Microsoft.PowerShell.Commands.PSUserAgent]::Chrome)
+            $ncsiResponse = Invoke-WebRequest -Uri "http://$($ncsiHost)/$($ncsiPath)" -UseBasicParsing -UserAgent ([Microsoft.PowerShell.Commands.PSUserAgent]::Chrome); # DevSkim: ignore DS137138 Insecure URL
         }
         catch {
             $ncsiResponse = $false


### PR DESCRIPTION
# Proposed Changes

Inline suppression of Microsoft DevSkim linter in:
- functions/Test-Network.ps1
- functions/Test-ModsPath.ps1

>if that works, I will try to come up with suppression of BAT encapsulated PoSh in `WAU Configurator.bat` where XML schema namespace triggers same warnings


