### PR TITLE
Update default_excluded_apps.txt

### DIFF
--- a/Sources/Winget-AutoUpdate/config/default_excluded_apps.txt
+++ b/Sources/Winget-AutoUpdate/config/default_excluded_apps.txt
@@ -1,4 +1,5 @@
 Google.Chrome*
+LibreWolf.LibreWolf
 Microsoft.Edge*
 Microsoft.Office
 Microsoft.OneDrive


### PR DESCRIPTION
# Proposed Changes

If you install LibreWolf from winget by default it will automatically install [LibreWolf-WinUpdater](https://codeberg.org/ltguillaume/librewolf-winupdater)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
