### PR TITLE
Try MSI first

### DIFF
--- a/Sources/Winget-AutoUpdate/functions/Get-WAUAvailableVersion.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Get-WAUAvailableVersion.ps1
@@ -10,12 +10,12 @@ function Get-WAUAvailableVersion {
 
         try {
             #Get latest pre-release info
-            $WAUurl = "https://api.github.com/repos/Romanitho/$GitHub_Repo/releases"
+            $WAUurl = "https://api.github.com/repos/Romanitho/$($GitHub_Repo)/releases"
             $WAUAvailableVersion = ((Invoke-WebRequest $WAUurl -UseBasicParsing | ConvertFrom-Json)[0].tag_name).Replace("v", "")
         }
         catch {
-            $url = "https://github.com/Romanitho/$GitHub_Repo/releases"
-            $link = ((Invoke-WebRequest $url -UseBasicParsing).Links.href -match "/$GitHub_Repo/releases/tag/v*")[0]
+            $url = "https://github.com/Romanitho/$($GitHub_Repo)/releases"
+            $link = ((Invoke-WebRequest $url -UseBasicParsing).Links.href -match "/$($GitHub_Repo)/releases/tag/v*")[0]
             $WAUAvailableVersion = $link.Trim().Split("v")[-1]
         }
 
@@ -24,12 +24,12 @@ function Get-WAUAvailableVersion {
 
         try {
             #Get latest stable info
-            $WAUurl = "https://api.github.com/repos/Romanitho/$GitHub_Repo/releases/latest"
+            $WAUurl = "https://api.github.com/repos/Romanitho/$($GitHub_Repo)/releases/latest"
             $WAUAvailableVersion = ((Invoke-WebRequest $WAUurl -UseBasicParsing | ConvertFrom-Json)[0].tag_name).Replace("v", "")
         }
         catch {
-            $url = "https://github.com/Romanitho/$GitHub_Repo/releases/latest"
-            $link = ((Invoke-WebRequest $url -UseBasicParsing).Links.href -match "/$GitHub_Repo/releases/tag/v*")[0]
+            $url = "https://github.com/Romanitho/$($GitHub_Repo)/releases/latest"
+            $link = ((Invoke-WebRequest $url -UseBasicParsing).Links.href -match "/$($GitHub_Repo)/releases/tag/v*")[0]
             $WAUAvailableVersion = $link.Trim().Split("v")[-1]
         }
 

--- a/Sources/Winget-AutoUpdate/functions/Invoke-PostUpdateActions.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Invoke-PostUpdateActions.ps1
@@ -156,7 +156,7 @@ function Invoke-PostUpdateActions {
 
     #Add 1 to counter file
     try {
-        Invoke-RestMethod -Uri "https://github.com/Romanitho/$GitHub_Repo/releases/download/v$($WAUConfig.DisplayVersion)/WAU_InstallCounter" | Out-Null
+        Invoke-RestMethod -Uri "https://github.com/Romanitho/$($GitHub_Repo)/releases/download/v$($WAUConfig.DisplayVersion)/WAU_InstallCounter" | Out-Null
     }
     catch {
         Write-ToLog "-> Not able to report installation." "Yellow"

--- a/Sources/Winget-AutoUpdate/functions/Update-WAU.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Update-WAU.ps1
@@ -2,7 +2,7 @@
 
 function Update-WAU {
 
-    $OnClickAction = "https://github.com/Romanitho/$GitHub_Repo/releases"
+    $OnClickAction = "https://github.com/Romanitho/$($GitHub_Repo)/releases"
     $Button1Text = $NotifLocale.local.outputs.output[10].message
 
     #Send available update notification
@@ -12,111 +12,114 @@ function Update-WAU {
     Start-NotifTask -Title $Title -Message $Message -MessageType $MessageType -Button1Action $OnClickAction -Button1Text $Button1Text
 
     #Run WAU update
+
+    #Try WAU.msi (v2) if available
     try {
-        #Try WAU.zip (v1)
+        #Download the msi
+        Write-ToLog "Downloading the GitHub Repository MSI version $WAUAvailableVersion" "Cyan"
+        $MsiFile = "$env:temp\WAU.msi"
+        Invoke-RestMethod -Uri "https://github.com/Romanitho/$($GitHub_Repo)/releases/download/v$($WAUAvailableVersion)/WAU.msi" -OutFile $MsiFile
 
-        #Force to create a zip file
-        $ZipFile = "$WorkingDir\WAU_update.zip"
-        New-Item $ZipFile -ItemType File -Force | Out-Null
+        #Migrate registry to save current WAU settings
+        Write-ToLog "Saving current config before updating with MSI"
+        $sourcePath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Winget-AutoUpdate"
+        $destinationPath = "HKLM:\SOFTWARE\Romanitho\Winget-AutoUpdate"
+        #Create the destination key if it doesn't exist
+        if (-not (Test-Path -Path $destinationPath)) {
+            New-Item -Path $destinationPath -ItemType Directory -Force
+            Write-ToLog "New registry key created."
+        }
+        #Retrieve the properties of the source key
+        $properties = Get-ItemProperty -Path $sourcePath
+        foreach ($property in $properties.PSObject.Properties) {
+            #Check if the value name starts with "WAU_"
+            if ($property.Name -like "WAU_*" -and $property.Name -notlike "WAU_PostUpdateActions*") {
+                #Copy the value to the destination key
+                Set-ItemProperty -Path $destinationPath -Name $property.Name -Value $property.Value
+                Write-ToLog "$($property.Name) saved."
+            }
+        }
 
-        #Download the zip
-        Write-ToLog "Downloading the GitHub Repository Zip version $WAUAvailableVersion" "Cyan"
-        Invoke-RestMethod -Uri "https://github.com/Romanitho/$GitHub_Repo/releases/download/v$($WAUAvailableVersion)/WAU.zip" -OutFile $ZipFile
+        #Stop ServiceUI
+        $ServiceUI = Get-Process -ProcessName serviceui -ErrorAction SilentlyContinue
+        if ($ServiceUI) {
+            try {
+                Write-ToLog "Stopping ServiceUI"
+                $ServiceUI | Stop-Process
+            }
+            catch {
+                Write-ToLog "Failed to stop ServiceUI"
+            }
+        }
 
-        #Extract Zip File
-        Write-ToLog "Unzipping the WAU Update package" "Cyan"
-        $location = "$WorkingDir\WAU_update"
-        Expand-Archive -Path $ZipFile -DestinationPath $location -Force
-        Get-ChildItem -Path $location -Recurse | Unblock-File
+        #Uninstall WAU v1
+        Write-ToLog "Uninstalling WAU v1"
+        Start-Process powershell -ArgumentList "-WindowStyle Hidden -ExecutionPolicy Bypass -Command `"$WorkingDir\WAU-Uninstall.ps1`"" -Wait
 
-        #Update scritps
+        #Update WAU and run
         Write-ToLog "Updating WAU..." "Yellow"
-        $TempPath = (Resolve-Path "$location\Winget-AutoUpdate\")[0].Path
-        $ServiceUI = Test-Path "$WorkingDir\ServiceUI.exe"
-        if ($TempPath -and $ServiceUI) {
-            #Do not copy ServiceUI if already existing, causing error if in use.
-            Copy-Item -Path "$TempPath\*" -Destination "$WorkingDir\" -Exclude ("icons", "ServiceUI.exe") -Recurse -Force
-        }
-        elseif ($TempPath) {
-            Copy-Item -Path "$TempPath\*" -Destination "$WorkingDir\" -Exclude "icons" -Recurse -Force
-        }
+        Start-Process msiexec.exe -ArgumentList "/i $MsiFile /qn /L*v ""$WorkingDir\logs\WAU-Installer.log"" RUN_WAU=YES INSTALLDIR=""$WorkingDir"""
 
-        #Remove update zip file and update temp folder
-        Write-ToLog "Done. Cleaning temp files..." "Cyan"
-        Remove-Item -Path $ZipFile -Force -ErrorAction SilentlyContinue
-        Remove-Item -Path $location -Recurse -Force -ErrorAction SilentlyContinue
-
-        #Set new version to registry
-        New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Winget-AutoUpdate" -Name "DisplayVersion" -Value $WAUAvailableVersion -Force | Out-Null
-
-        #Set Post Update actions to 1
-        New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Winget-AutoUpdate" -Name "WAU_PostUpdateActions" -Value 1 -Force | Out-Null
-
-        #Send success Notif
-        Write-ToLog "WAU Update completed." "Green"
-        $Title = $NotifLocale.local.outputs.output[3].title -f "Winget-AutoUpdate"
-        $Message = $NotifLocale.local.outputs.output[3].message -f $WAUAvailableVersion
-        $MessageType = "success"
-        Start-NotifTask -Title $Title -Message $Message -MessageType $MessageType -Button1Action $OnClickAction -Button1Text $Button1Text
-
-        #Rerun with newer version
-        Write-ToLog "Re-run WAU"
-        Start-Process powershell -ArgumentList "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command `"$WorkingDir\winget-upgrade.ps1`""
-
-        exit
-
+        Exit 0
     }
 
     catch {
 
-        #Try WAU.msi (v2)
         try {
-            #Download the msi
-            Write-ToLog "Downloading the GitHub Repository MSI version $WAUAvailableVersion" "Cyan"
-            $MsiFile = "$env:temp\WAU.msi"
-            Invoke-RestMethod -Uri "https://github.com/Romanitho/$GitHub_Repo/releases/download/v$($WAUAvailableVersion)/WAU.msi" -OutFile $MsiFile
+            #Try WAU.zip (v1)
 
-            #Migrate registry to save current WAU settings
-            Write-ToLog "Saving current config before updating with MSI"
-            $sourcePath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Winget-AutoUpdate"
-            $destinationPath = "HKLM:\SOFTWARE\Romanitho\Winget-AutoUpdate"
-            #Create the destination key if it doesn't exist
-            if (-not (Test-Path -Path $destinationPath)) {
-                New-Item -Path $destinationPath -ItemType Directory -Force
-                Write-ToLog "New registry key created."
-            }
-            #Retrieve the properties of the source key
-            $properties = Get-ItemProperty -Path $sourcePath
-            foreach ($property in $properties.PSObject.Properties) {
-                #Check if the value name starts with "WAU_"
-                if ($property.Name -like "WAU_*" -and $property.Name -notlike "WAU_PostUpdateActions*") {
-                    #Copy the value to the destination key
-                    Set-ItemProperty -Path $destinationPath -Name $property.Name -Value $property.Value
-                    Write-ToLog "$($property.Name) saved."
-                }
-            }
+            Write-ToLog "No MSI found yet."
 
-            #Stop ServiceUI
-            $ServiceUI = Get-Process -ProcessName serviceui -ErrorAction SilentlyContinue
-            if ($ServiceUI) {
-                try {
-                    Write-ToLog "Stopping ServiceUI"
-                    $ServiceUI | Stop-Process
-                }
-                catch {
-                    Write-ToLog "Failed to stop ServiceUI"
-                }
-            }
+            #Force to create a zip file
+            $ZipFile = "$WorkingDir\WAU_update.zip"
+            New-Item $ZipFile -ItemType File -Force | Out-Null
 
-            #Uninstall WAU v1
-            Write-ToLog "Uninstalling WAU v1"
-            Start-Process powershell -ArgumentList "-WindowStyle Hidden -ExecutionPolicy Bypass -Command `"$WorkingDir\WAU-Uninstall.ps1`"" -Wait
+            #Download the zip
+            Write-ToLog "Downloading the GitHub Repository Zip version $WAUAvailableVersion" "Cyan"
+            Invoke-RestMethod -Uri "https://github.com/Romanitho/$($GitHub_Repo)/releases/download/v$($WAUAvailableVersion)/WAU.zip" -OutFile $ZipFile
 
-            #Update WAU and run
+            #Extract Zip File
+            Write-ToLog "Unzipping the WAU Update package" "Cyan"
+            $location = "$WorkingDir\WAU_update"
+            Expand-Archive -Path $ZipFile -DestinationPath $location -Force
+            Get-ChildItem -Path $location -Recurse | Unblock-File
+
+            #Update scritps
             Write-ToLog "Updating WAU..." "Yellow"
-            Start-Process msiexec.exe -ArgumentList "/i $MsiFile /qn /L*v ""$WorkingDir\logs\WAU-Installer.log"" RUN_WAU=YES INSTALLDIR=""$WorkingDir"""
+            $TempPath = (Resolve-Path "$location\Winget-AutoUpdate\")[0].Path
+            $ServiceUI = Test-Path "$WorkingDir\ServiceUI.exe"
+            if ($TempPath -and $ServiceUI) {
+                #Do not copy ServiceUI if already existing, causing error if in use.
+                Copy-Item -Path "$TempPath\*" -Destination "$WorkingDir\" -Exclude ("icons", "ServiceUI.exe") -Recurse -Force
+            }
+            elseif ($TempPath) {
+                Copy-Item -Path "$TempPath\*" -Destination "$WorkingDir\" -Exclude "icons" -Recurse -Force
+            }
 
-            Exit 0
+            #Remove update zip file and update temp folder
+            Write-ToLog "Done. Cleaning temp files..." "Cyan"
+            Remove-Item -Path $ZipFile -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path $location -Recurse -Force -ErrorAction SilentlyContinue
+
+            #Set new version to registry
+            New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Winget-AutoUpdate" -Name "DisplayVersion" -Value $WAUAvailableVersion -Force | Out-Null
+
+            #Set Post Update actions to 1
+            New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Winget-AutoUpdate" -Name "WAU_PostUpdateActions" -Value 1 -Force | Out-Null
+
+            #Send success Notif
+            Write-ToLog "WAU Update completed." "Green"
+            $Title = $NotifLocale.local.outputs.output[3].title -f "Winget-AutoUpdate"
+            $Message = $NotifLocale.local.outputs.output[3].message -f $WAUAvailableVersion
+            $MessageType = "success"
+            Start-NotifTask -Title $Title -Message $Message -MessageType $MessageType -Button1Action $OnClickAction -Button1Text $Button1Text
+
+            #Rerun with newer version
+            Write-ToLog "Re-run WAU"
+            Start-Process powershell -ArgumentList "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command `"$WorkingDir\winget-upgrade.ps1`""
+
+            exit
+
         }
 
         catch {
@@ -127,6 +130,8 @@ function Update-WAU {
             $MessageType = "error"
             Start-NotifTask -Title $Title -Message $Message -MessageType $MessageType -Button1Action $OnClickAction -Button1Text $Button1Text
             Write-ToLog "WAU Update failed" "Red"
+
+            Remove-Item -Path $ZipFile -Force -ErrorAction SilentlyContinue
 
         }
     }


### PR DESCRIPTION
# Proposed Changes


Changing the way updates will behave when the MSI version is released:

- First, WAU will try to update using the MSI version.
- If the MSI version is unavailable (not released yet), it will attempt to update using the WAU.zip package as it does today.

This way, when the WAU.msi version is released, we will also include the latest WAU.zip in the assets. This ensures that if you have a very old WAU version, it will first update to the latest WAU.zip and then update itself to the latest MSI version.
