### PR TITLE
Write User logs to AppData folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can easily translate toast notifications by creating your locale xml config 
 WAU runs ,by default, at logon. You can configure the frequency with options (Daily, BiDaily, Weekly, BiWeekly, Monthly or Never).
 
 ### Log location
-You can find logs in install location, in logs folder for priviledged exetions. For user runs (Winget-Install.ps1) a log file will be created at %AppData%\Winget-AutoUpdate\Logs .<br>
+You can find logs in install location, in logs folder for priviledged executions. For user runs (Winget-Install.ps1) a log file will be created at %AppData%\Winget-AutoUpdate\Logs .<br>
 If **Intune Management Extension** is installed, a **SymLink** (WAU-updates.log) is created under **C:\ProgramData\Microsoft\IntuneManagementExtension\Logs**<br>
 If you are deploying winget Apps with [Winget-Install](https://github.com/Romanitho/Winget-AutoUpdate/blob/main/Sources/Winget-AutoUpdate/Winget-Install.ps1) a **SymLink** (WAU-install.log & WAU-user_%username%.log) is also created under **C:\ProgramData\Microsoft\IntuneManagementExtension\Logs**
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ You can easily translate toast notifications by creating your locale xml config 
 WAU runs ,by default, at logon. You can configure the frequency with options (Daily, BiDaily, Weekly, BiWeekly, Monthly or Never).
 
 ### Log location
-You can find logs in install location, in logs folder.<br>
+You can find logs in install location, in logs folder for priviledged exetions. For user runs (Winget-Install.ps1) a log file will be created at %AppData%\Winget-AutoUpdate\Logs .<br>
 If **Intune Management Extension** is installed, a **SymLink** (WAU-updates.log) is created under **C:\ProgramData\Microsoft\IntuneManagementExtension\Logs**<br>
-If you are deploying winget Apps with [Winget-Install](https://github.com/Romanitho/Winget-AutoUpdate/blob/main/Sources/Winget-AutoUpdate/Winget-Install.ps1) a **SymLink** (WAU-install.log) is also created under **C:\ProgramData\Microsoft\IntuneManagementExtension\Logs**
+If you are deploying winget Apps with [Winget-Install](https://github.com/Romanitho/Winget-AutoUpdate/blob/main/Sources/Winget-AutoUpdate/Winget-Install.ps1) a **SymLink** (WAU-install.log & WAU-user_%username%.log) is also created under **C:\ProgramData\Microsoft\IntuneManagementExtension\Logs**
 
 ### "Unknown" App version
 As explained in this [post](https://github.com/microsoft/winget-cli/issues/1255), Winget cannot detect the current version of some installed apps. We decided to skip managing these apps with WAU to avoid retries each time WAU runs:

--- a/Sources/Winget-AutoUpdate/Winget-Install.ps1
+++ b/Sources/Winget-AutoUpdate/Winget-Install.ps1
@@ -314,29 +314,30 @@ $WAURegKey = "HKLM:\SOFTWARE\Romanitho\Winget-AutoUpdate\"
 $Script:WAUInstallLocation = Get-ItemProperty $WAURegKey -ErrorAction SilentlyContinue | Select-Object -ExpandProperty InstallLocation
 $Script:WAUModsLocation = Join-Path -Path $WAUInstallLocation -ChildPath "mods"
 
-#LogPath initialization
-if (!($LogPath)) {
-    #If LogPath is not set, get WAU log path
-    if ($WAUInstallLocation) {
-        $LogPath = "$WAUInstallLocation\Logs"
+#Log file & LogPath initialization
+if ($IsElevated) {
+    if (!($LogPath)) {
+        #If LogPath is not set, get WAU log path
+        if ($WAUInstallLocation) {
+            $LogPath = "$WAUInstallLocation\Logs"
+        }
+        else {
+            #Else, set a default one
+            $LogPath = "$env:ProgramData\Winget-AutoUpdate\Logs"
+        }
     }
-    else {
-        #Else, set a default one
-        $LogPath = "$env:ProgramData\Winget-AutoUpdate\Logs"
+    $Script:LogFile = "$LogPath\install.log"
+}
+else {
+    if (!($LogPath)) {
+        $LogPath = "C:\Users\$env:UserName\AppData\Roaming\Winget-AutoUpdate\Logs"
     }
+    $Script:LogFile = "$LogPath\install_$env:UserName.log"
 }
 
 #Logs initialization
 if (!(Test-Path $LogPath)) {
     New-Item -ItemType Directory -Force -Path $LogPath | Out-Null
-}
-
-#Log file
-if ($IsElevated) {
-    $Script:LogFile = "$LogPath\install.log"
-}
-else {
-    $Script:LogFile = "$LogPath\install_$env:UserName.log"
 }
 
 #Log Header

--- a/Sources/Winget-AutoUpdate/functions/Install-Prerequisites.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Install-Prerequisites.ps1
@@ -139,25 +139,6 @@ function Install-Prerequisites {
         else {
             Write-ToLog "-> WinGet is up to date: v$WinGetInstalledVersion" "Green"
         }
-        if (Test-Path "$WorkingDir\logs") {
-            $NewAcl = Get-Acl -Path "$WorkingDir\logs"
-            $identity = New-Object System.Security.Principal.SecurityIdentifier "S-1-1-0"  # S-1-1-0 stands for "Everyone"
-            $hasModifyPermission = $NewAcl.Access | Where-Object {
-                $_.IdentityReference -eq $identity -and $_.FileSystemRights -match "Modify" -and $_.AccessControlType -eq "Allow"
-            }
-        
-            if (-not $hasModifyPermission) {
-                Write-ToLog "-> Adjusting log folder ($WorkingDir\logs) permissions to allow Modify access for Everyone" "Green"
-        
-                $fileSystemRights = "Modify"
-                $type = "Allow"
-                $fileSystemAccessRuleArgumentList = $identity, $fileSystemRights, $type
-                $fileSystemAccessRule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList $fileSystemAccessRuleArgumentList
-                $NewAcl.SetAccessRule($fileSystemAccessRule)
-                Set-Acl -Path "$WorkingDir\logs" -AclObject $NewAcl
-            }
-        }
-
         Write-ToLog "Prerequisites checked. OK" "Green"
 
     }

--- a/Sources/Winget-AutoUpdate/functions/Install-Prerequisites.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Install-Prerequisites.ps1
@@ -139,6 +139,24 @@ function Install-Prerequisites {
         else {
             Write-ToLog "-> WinGet is up to date: v$WinGetInstalledVersion" "Green"
         }
+        if (Test-Path "$WorkingDir\logs") {
+            $NewAcl = Get-Acl -Path "$WorkingDir\logs"
+            $identity = New-Object System.Security.Principal.SecurityIdentifier "S-1-1-0"  # S-1-1-0 stands for "Everyone"
+            $hasModifyPermission = $NewAcl.Access | Where-Object {
+                $_.IdentityReference -eq $identity -and $_.FileSystemRights -match "Modify" -and $_.AccessControlType -eq "Allow"
+            }
+        
+            if (-not $hasModifyPermission) {
+                Write-ToLog "-> Adjusting log folder ($WorkingDir\logs) permissions to allow Modify access for Everyone" "Green"
+        
+                $fileSystemRights = "Modify"
+                $type = "Allow"
+                $fileSystemAccessRuleArgumentList = $identity, $fileSystemRights, $type
+                $fileSystemAccessRule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList $fileSystemAccessRuleArgumentList
+                $NewAcl.SetAccessRule($fileSystemAccessRule)
+                Set-Acl -Path "$WorkingDir\logs" -AclObject $NewAcl
+            }
+        }
 
         Write-ToLog "Prerequisites checked. OK" "Green"
 


### PR DESCRIPTION
# Proposed Changes
As described in #752 it wont work to write user logs since WAU2.0.0, this affected Winget-Install.ps1 runs within the user (seems to work for WAU user runs). 
We are now checking on every run, if the folder permissions are correctly set to allow "everyone" to do everything within the logs folder and if the permissions are missing, we are setting it. 

Please let me know, if "Install-Prerequisites.ps1" is a good place to check this, or if we should move it somewhere to the WAU installation itself (dont know which file is responsible for this?).

## Related Issues

#752
