### PR TITLE
Remove calling Invoke-PostUpdateActions 

### DIFF
--- a/Sources/Winget-AutoUpdate/Winget-Upgrade.ps1
+++ b/Sources/Winget-AutoUpdate/Winget-Upgrade.ps1
@@ -105,10 +105,6 @@ if ($IsSystem) {
         Write-ToLog "An Exception occurred during Log Rotation..."
     }
 
-    #Run post update actions if necessary if run as System
-    if (!($WAUConfig.WAU_PostUpdateActions -eq 0)) {
-        Invoke-PostUpdateActions
-    }
     #Run Scope Machine function if run as System
     Add-ScopeMachine
 }


### PR DESCRIPTION
# Proposed Changes
Since WAU 2.0 Invoke-PostUpdateActions is not needed anymore, but its called within WAU and throws an error . WAU_PostUpdateActions also does not exist anymore

## Related Issues
#768