### PR TITLE
Step towards experimental group of settings in ADMX Policies

### DIFF
--- a/Sources/Policies/ADMX/WAU.admx
+++ b/Sources/Policies/ADMX/WAU.admx
@@ -8,9 +8,15 @@
     <definitions>
       <definition name="SUPPORTED_WAU_1_16_0" displayName="$(string.SUPPORTED_WAU_1_16_0)"/>
       <definition name="SUPPORTED_WAU_1_16_5" displayName="$(string.SUPPORTED_WAU_1_16_5)"/>
+	  <definition name="SUPPORTED_WAU_EXPERIMENTAL" displayName="$(string.SUPPORTED_WAU_EXPERIMENTAL)"/>
     </definitions>
   </supportedOn>
-  <categories><category displayName="$(string.WAU)" name="WAU"/></categories>
+  <categories>
+  <category displayName="$(string.WAU)" name="WAU"/>
+    <category name="Experimental" displayName="$(string.WAUEX)">
+      <parentCategory ref="WAU" />
+    </category>
+  </categories>
   <policies>
   	<policy name="ActivateGPOManagement_Enable" class="Machine" displayName="$(string.ActivateGPOManagement_Name)" explainText="$(string.ActivateGPOManagement_Explain)" key="Software\Policies\Romanitho\Winget-AutoUpdate" valueName="WAU_ActivateGPOManagement">
       <parentCategory ref="WAU"/>
@@ -348,6 +354,13 @@
       <supportedOn ref="WAU:SUPPORTED_WAU_1_16_0"/>
       <elements>
         <text id="MaxLogSize" valueName="WAU_MaxLogSize" />
+      </elements>
+    </policy>
+  	<policy name="WingetSourceCustom_Enable" class="Machine" displayName="$(string.WingetSourceCustom_Name)" explainText="$(string.WingetSourceCustom_Explain)" key="Software\Policies\Romanitho\Winget-AutoUpdate" presentation="$(presentation.WingetSourceCustom)" >
+      <parentCategory ref="Experimental"/>
+      <supportedOn ref="WAU:SUPPORTED_WAU_EXPERIMENTAL"/>
+      <elements>
+        <text id="WingetSourceCustom" valueName="WAU_WingetSourceCustom" />
       </elements>
     </policy>
   </policies>

--- a/Sources/Policies/ADMX/en-US/WAU.adml
+++ b/Sources/Policies/ADMX/en-US/WAU.adml
@@ -5,8 +5,10 @@
   <resources >
     <stringTable >
       <string id="WAU">Winget-AutoUpdate</string>
+	  <string id="WAUEX">Experimental</string>
       <string id="SUPPORTED_WAU_1_16_0">Winget-AutoUpdate version 1.16.0 or later</string>
       <string id="SUPPORTED_WAU_1_16_5">Winget-AutoUpdate version 1.16.5 or later</string>
+	  <string id="SUPPORTED_WAU_EXPERIMENTAL">Winget-AutoUpdate Experimental, subject to change, do not use on PROD</string>
       <string id="ActivateGPOManagement_Name">Activate WAU GPO Management</string>
       <string id="ActivateGPOManagement_Explain">This policy setting is an overriding toggle for GPO Management of Winget-AutoUpdate.</string>
       <string id="BypassListForUsers_Name">Bypass Black/White list for User</string>
@@ -140,6 +142,13 @@ If this policy is disabled or not configured, the default number is used.</strin
 Default size is 1048576 = 1 MB
 
 If this policy is disabled or not configured, the default size is used.</string>
+      <string id="WingetSourceCustom_Name">Use custom Winget Source repository</string>
+      <string id="WingetSourceCustom_Explain">This policy setting specifies whether to use winget tool with custom repository or not:
+(WAU - Check for updated Apps)
+
+If this policy is enabled, WAU will TRY to use a custom repo instead of the built-in/default one called winget.
+
+If this policy is disabled or not configured, the default is always the built-in winget.</string>
     </stringTable>
     <presentationTable>
       <presentation id="BlackList">
@@ -180,6 +189,11 @@ If this policy is disabled or not configured, the default size is used.</string>
       <presentation id="MaxLogSize">
         <textBox refId="MaxLogSize">
           <label>Size of the log file:</label>
+        </textBox>
+      </presentation>
+      <presentation id="WingetSourceCustom">
+        <textBox refId="WingetSourceCustom">
+          <label>Name of custom winget source:</label>
         </textBox>
       </presentation>
     </presentationTable>

--- a/Sources/Winget-AutoUpdate/Winget-Upgrade.ps1
+++ b/Sources/Winget-AutoUpdate/Winget-Upgrade.ps1
@@ -329,8 +329,8 @@ if (Test-Network) {
         }
 
         #Get outdated Winget packages
-        Write-ToLog "Checking application updates on Winget Repository..." "yellow"
-        $outdated = Get-WingetOutdatedApps
+        Write-ToLog "Checking application updates on Winget Repository named '$($Script:WingetSourceCustom)' .." "yellow"
+        $outdated = Get-WingetOutdatedApps -src $Script:WingetSourceCustom;
 
         #If something unusual happened or no update found
         if ($outdated -like "No update found.*") {

--- a/Sources/Winget-AutoUpdate/Winget-Upgrade.ps1
+++ b/Sources/Winget-AutoUpdate/Winget-Upgrade.ps1
@@ -150,53 +150,56 @@ if ($true -eq $IsSystem) {
 }
 #endregion Run Scope Machine function if run as System
 
-#Get Notif Locale function
-$LocaleDisplayName = Get-NotifLocale
-Write-ToLog "Notification Level: $($WAUConfig.WAU_NotificationLevel). Notification Language: $LocaleDisplayName" "Cyan"
+#region Get Notif Locale function
+    [string]$LocaleDisplayName = Get-NotifLocale;
+    Write-ToLog "Notification Level: $($WAUConfig.WAU_NotificationLevel). Notification Language: $LocaleDisplayName" "Cyan";
+#endregion 
 
 #Check network connectivity
 if (Test-Network) {
 
     #Check prerequisites
-    if ($IsSystem) {
-        Install-Prerequisites
+    if ($true -eq $IsSystem) {
+        Install-Prerequisites;
     }
 
     #Check if Winget is installed and get Winget cmd
-    $Script:Winget = Get-WingetCmd
+    [string]$Script:Winget = Get-WingetCmd;
+    Write-ToLog "Selected winget instance: $($Script:Winget)";
 
-    if ($Winget) {
+    if ($Script:Winget) {
 
-        if ($IsSystem) {
+        if ($true -eq $IsSystem) {
 
             #Get Current Version
-            $WAUCurrentVersion = $WAUConfig.ProductVersion
-            Write-ToLog "WAU current version: $WAUCurrentVersion"
+            $WAUCurrentVersion = $WAUConfig.ProductVersion;
+            Write-ToLog "WAU current version: $WAUCurrentVersion";
 
             #Check if WAU update feature is enabled or not if run as System
-            $WAUDisableAutoUpdate = $WAUConfig.WAU_DisableAutoUpdate
+            $WAUDisableAutoUpdate = $WAUConfig.WAU_DisableAutoUpdate;
             #If yes then check WAU update if run as System
             if ($WAUDisableAutoUpdate -eq 1) {
-                Write-ToLog "WAU AutoUpdate is Disabled." "Gray"
+                Write-ToLog "WAU AutoUpdate is Disabled." "Gray";
             }
             else {
-                Write-ToLog "WAU AutoUpdate is Enabled." "Green"
+                Write-ToLog "WAU AutoUpdate is Enabled." "Green";
                 #Get Available Version
-                $Script:WAUAvailableVersion = Get-WAUAvailableVersion
+                $Script:WAUAvailableVersion = Get-WAUAvailableVersion;
                 #Compare
                 if ([version]$WAUAvailableVersion.replace("-n", "") -gt [version]$WAUCurrentVersion.replace("-n", "")) {
                     #If new version is available, update it
-                    Write-ToLog "WAU Available version: $WAUAvailableVersion" "Yellow"
-                    Update-WAU
+                    Write-ToLog "WAU Available version: $WAUAvailableVersion" "Yellow";
+                    Update-WAU;
                 }
                 else {
-                    Write-ToLog "WAU is up to date." "Green"
+                    Write-ToLog "WAU is up to date." "Green";
                 }
             }
 
             #Delete previous list_/winget_error (if they exist) if run as System
-            if (Test-Path "$WorkingDir\logs\error.txt") {
-                Remove-Item "$WorkingDir\logs\error.txt" -Force
+            [string]$fp4 = [System.IO.Path]::Combine($Script:WorkingDir, 'logs', 'error.txt');
+            if (Test-Path $fp4) {
+                Remove-Item $fp4 -Force;
             }
 
             #Get External ListPath if run as System

--- a/Sources/Winget-AutoUpdate/Winget-Upgrade.ps1
+++ b/Sources/Winget-AutoUpdate/Winget-Upgrade.ps1
@@ -115,7 +115,7 @@ else {
     Write-ToLog -LogMsg "CHECK FOR APP UPDATES (User context)" -IsHeader
 }
 
-#region Log running context and more...
+#region Log running context
 if ($true -eq $IsSystem) {
 
     # Maximum number of log files to keep. Default is 3. Setting MaxLogFiles to 0 will keep all log files.
@@ -141,11 +141,14 @@ if ($true -eq $IsSystem) {
     if ($false -eq $LogRotate) {
         Write-ToLog "An Exception occurred during Log Rotation..."
     }
-
-    #Run Scope Machine function if run as System
-    Add-ScopeMachine
 }
-#endregion Log running context and more...
+#endregion Log running context
+
+#region Run Scope Machine function if run as System
+if ($true -eq $IsSystem) {
+    Add-ScopeMachine;
+}
+#endregion Run Scope Machine function if run as System
 
 #Get Notif Locale function
 $LocaleDisplayName = Get-NotifLocale

--- a/Sources/Winget-AutoUpdate/Winget-Upgrade.ps1
+++ b/Sources/Winget-AutoUpdate/Winget-Upgrade.ps1
@@ -423,7 +423,7 @@ if (Test-Network) {
             Else {
                 #Get Winget system apps to escape them before running user context
                 Write-ToLog "User logged on, get a list of installed Winget apps in System context..."
-                Get-WingetSystemApps
+                Get-WingetSystemApps -src $Script:WingetSourceCustom;
 
                 #Run user context scheduled task
                 Write-ToLog "Starting WAU in User context..."

--- a/Sources/Winget-AutoUpdate/functions/Get-WingetCmd.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Get-WingetCmd.ps1
@@ -1,23 +1,27 @@
 #Function to get the winget command regarding execution context (User, System...)
 
 Function Get-WingetCmd {
-
-    $WingetCmd = $null
+    [OutputType([String])]
+    $WingetCmd = [string]::Empty;
 
     #Get WinGet Path
+    # default winget path (in system context)
+    [string]$ps = "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_8wekyb3d8bbwe\winget.exe";
+
+    #default winget path (in user context)
+    [string]$pu = "$env:LocalAppData\Microsoft\WindowsApps\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\winget.exe";
+
     try {
         #Get Admin Context Winget Location
-        $WingetInfo = (Get-Item "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_8wekyb3d8bbwe\winget.exe").VersionInfo | Sort-Object -Property FileVersionRaw
+        $WingetInfo = (Get-Item -Path $ps).VersionInfo | Sort-Object -Property FileVersionRaw -Descending | Select-Object -First 1;
         #If multiple versions, pick most recent one
-        $WingetCmd = $WingetInfo[-1].FileName
+        $WingetCmd = $WingetInfo.FileName;
     }
     catch {
         #Get User context Winget Location
-        if (Test-Path "$env:LocalAppData\Microsoft\WindowsApps\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\winget.exe") {
-            $WingetCmd = "$env:LocalAppData\Microsoft\WindowsApps\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\winget.exe"
+        if (Test-Path -Path $pu -PathType Leaf) {
+            $WingetCmd = $pu;
         }
     }
-
-    return $WingetCmd
-
+    return $WingetCmd;
 }

--- a/Sources/Winget-AutoUpdate/functions/Get-WingetOutdatedApps.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Get-WingetOutdatedApps.ps1
@@ -1,6 +1,12 @@
 #Function to get the outdated app list, in formatted array
 
 function Get-WingetOutdatedApps {
+
+Param(
+    [Parameter(Position=0,Mandatory=$True,HelpMessage="You MUST supply value for winget repo, we need it")]
+    [ValidateNotNullorEmpty()]
+    [string]$src
+)
     class Software {
         [string]$Name
         [string]$Id
@@ -9,7 +15,7 @@ function Get-WingetOutdatedApps {
     }
 
     #Get list of available upgrades on winget format
-    $upgradeResult = & $Winget upgrade --source winget | Where-Object { $_ -notlike "   *" } | Out-String
+    $upgradeResult = & $Winget upgrade --source $src | Where-Object { $_ -notlike "   *" } | Out-String
 
     #Start Conversion of winget format to an array. Check if "-----" exists (Winget Error Handling)
     if (!($upgradeResult -match "-----")) {

--- a/Sources/Winget-AutoUpdate/functions/Get-WingetSystemApps.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Get-WingetSystemApps.ps1
@@ -1,10 +1,14 @@
 function Get-WingetSystemApps {
-
+Param(
+    [Parameter(Position=0,Mandatory=$True,HelpMessage="You MUST supply value for winget repo, we need it")]
+    [ValidateNotNullorEmpty()]
+    [string]$src
+)
     #Json File, where to export system installed apps
     $jsonFile = "$WorkingDir\config\winget_system_apps.txt"
 
     #Get list of installed Winget apps to json file
-    & $Winget export -o $jsonFile --accept-source-agreements -s winget | Out-Null
+    & $Winget export -o $jsonFile --accept-source-agreements -s $src | Out-Null
 
     #Convert json file to txt file with app ids
     $InstalledApps = get-content $jsonFile | ConvertFrom-Json

--- a/Sources/Winget-AutoUpdate/functions/Invoke-LogRotation.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Invoke-LogRotation.ps1
@@ -1,10 +1,15 @@
 #Function to rotate the logs
 
-function Invoke-LogRotation ($LogFile, $MaxLogFiles, $MaxLogSize) {
+function Invoke-LogRotation {
+    [OutputType([Bool])]
+    param(
+        [string]$LogFile, 
+        [Int32]$MaxLogFiles, 
+        [Int64]$MaxLogSize
+    )
 
     # if MaxLogFiles is 1 just keep the original one and let it grow
     if (-not($MaxLogFiles -eq 1)) {
-
         try {
             # get current size of log file
             $currentSize = (Get-Item $LogFile).Length
@@ -47,15 +52,12 @@ function Invoke-LogRotation ($LogFile, $MaxLogFiles, $MaxLogSize) {
                 #Log Header
                 Write-ToLog -LogMsg "CHECK FOR APP UPDATES (System context)" -IsHeader
                 Write-ToLog -LogMsg "Max Log Size reached: $MaxLogSize bytes - Rotated Logs"
-
-                Return $True
             }
+            # end of try block
+            Return $true;
         }
-
         catch {
-            Return $False
+            Return $false;
         }
-
     }
-
 }


### PR DESCRIPTION
# Proposed Changes

> Given the ever-increasing number of WAU users, it would be beneficial to separate experimental settings from those already in production. The proposed pull request brings such a possibility.
I hope that this will be the foundation for future settings that will not conflict with those already tested in this way.
![image](https://github.com/user-attachments/assets/6dff9769-53d6-429f-a3b1-ba169724b76d)

## Related Issues
> [issue link](https://github.com/Romanitho/Winget-AutoUpdate/issues/780)
In the attached example, a text field has been added indicating the name of the non-default repository name that WAU could use when calling winget.exe sub-commands. The logic in PS1 scripts will be provided in the next commits.

| Setting Enabled | Setting disabled |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/1971d264-3df1-4bf0-a453-5643624e4223) | ![image](https://github.com/user-attachments/assets/a8524da9-2ab1-48a0-a26d-52f91657bec3) |

BR
AD