### PR TITLE
feat: add support for `--custom` parameter via `AppID-custom.txt`

### DIFF
--- a/Sources/Winget-AutoUpdate/functions/Test-Mods.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Test-Mods.ps1
@@ -4,6 +4,7 @@ function Test-Mods ($app) {
 
     #Takes care of a null situation
     $ModsPreInstall = $null
+    $ModsCustom = $null
     $ModsOverride = $null
     $ModsUpgrade = $null
     $ModsInstall = $null
@@ -19,6 +20,9 @@ function Test-Mods ($app) {
     if (Test-Path "$Mods\$app-*") {
         if (Test-Path "$Mods\$app-preinstall.ps1") {
             $ModsPreInstall = "$Mods\$app-preinstall.ps1"
+        }
+        if (Test-Path "$Mods\$app-custom.txt") {
+            $ModsOverride = Get-Content "$Mods\$app-custom.txt" -Raw
         }
         if (Test-Path "$Mods\$app-override.txt") {
             $ModsOverride = Get-Content "$Mods\$app-override.txt" -Raw
@@ -38,6 +42,6 @@ function Test-Mods ($app) {
         }
     }
 
-    return $ModsPreInstall, $ModsOverride, $ModsUpgrade, $ModsInstall, $ModsInstalled, $ModsNotInstalled
+    return $ModsPreInstall, $ModsCustom, $ModsOverride, $ModsUpgrade, $ModsInstall, $ModsInstalled, $ModsNotInstalled
 
 }

--- a/Sources/Winget-AutoUpdate/functions/Test-Mods.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Test-Mods.ps1
@@ -4,8 +4,8 @@ function Test-Mods ($app) {
 
     #Takes care of a null situation
     $ModsPreInstall = $null
-    $ModsCustom = $null
     $ModsOverride = $null
+    $ModsCustom = $null
     $ModsUpgrade = $null
     $ModsInstall = $null
     $ModsInstalled = $null
@@ -20,12 +20,12 @@ function Test-Mods ($app) {
     if (Test-Path "$Mods\$app-*") {
         if (Test-Path "$Mods\$app-preinstall.ps1") {
             $ModsPreInstall = "$Mods\$app-preinstall.ps1"
-        }
-        if (Test-Path "$Mods\$app-custom.txt") {
-            $ModsOverride = Get-Content "$Mods\$app-custom.txt" -Raw
-        }
+        } 
         if (Test-Path "$Mods\$app-override.txt") {
             $ModsOverride = Get-Content "$Mods\$app-override.txt" -Raw
+        }
+        if (Test-Path "$Mods\$app-custom.txt") {
+            $ModsCustom = Get-Content "$Mods\$app-custom.txt" -Raw
         }
         if (Test-Path "$Mods\$app-install.ps1") {
             $ModsInstall = "$Mods\$app-install.ps1"
@@ -42,6 +42,6 @@ function Test-Mods ($app) {
         }
     }
 
-    return $ModsPreInstall, $ModsCustom, $ModsOverride, $ModsUpgrade, $ModsInstall, $ModsInstalled, $ModsNotInstalled
+    return $ModsPreInstall, $ModsOverride, $ModsCustom, $ModsUpgrade, $ModsInstall, $ModsInstalled, $ModsNotInstalled
 
 }

--- a/Sources/Winget-AutoUpdate/functions/Update-App.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Update-App.ps1
@@ -35,7 +35,7 @@ Function Update-App ($app) {
     }
     elseif ($ModsCustom) {
          Write-ToLog "-> Running (customizing default): Winget upgrade --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget -h --custom $ModsCustom"
-         & $Winget upgrade --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget --custom $ModsCustom | Where-Object { $_ -notlike "   *" } | Tee-Object -file $LogFile -Append
+         & $Winget upgrade --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget -h --custom $ModsCustom | Where-Object { $_ -notlike "   *" } | Tee-Object -file $LogFile -Append
     }
     else {
         Write-ToLog "-> Running: Winget upgrade --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget -h"
@@ -71,7 +71,7 @@ Function Update-App ($app) {
             }
             elseif ($ModsCustom) {
                  Write-ToLog "-> Running (customizing default): Winget install --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget -h --force --custom $ModsCustom"
-                 & $Winget install --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget --custom $ModsCustom | Where-Object { $_ -notlike "   *" } | Tee-Object -file $LogFile -Append
+                 & $Winget install --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget -h --force --custom $ModsCustom | Where-Object { $_ -notlike "   *" } | Tee-Object -file $LogFile -Append
             }
             else {
                 Write-ToLog "-> Running: Winget install --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget -h --force"

--- a/Sources/Winget-AutoUpdate/functions/Update-App.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Update-App.ps1
@@ -17,7 +17,7 @@ Function Update-App ($app) {
     Start-NotifTask -Title $Title -Message $Message -MessageType $MessageType -Balise $Balise -Button1Action $ReleaseNoteURL -Button1Text $Button1Text
 
     #Check if mods exist for preinstall/override/upgrade/install/installed/notinstalled
-    $ModsPreInstall, $ModsOverride, $ModsUpgrade, $ModsInstall, $ModsInstalled, $ModsNotInstalled = Test-Mods $($app.Id)
+    $ModsPreInstall, $ModsOverride, $ModsCustom $ModsUpgrade, $ModsInstall, $ModsInstalled, $ModsNotInstalled = Test-Mods $($app.Id)
 
     #Winget upgrade
     Write-ToLog "##########   WINGET UPGRADE PROCESS STARTS FOR APPLICATION ID '$($App.Id)'   ##########" "Gray"
@@ -32,6 +32,10 @@ Function Update-App ($app) {
     if ($ModsOverride) {
         Write-ToLog "-> Running (overriding default): Winget upgrade --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget --override $ModsOverride"
         & $Winget upgrade --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget --override $ModsOverride | Where-Object { $_ -notlike "   *" } | Tee-Object -file $LogFile -Append
+    }
+    elseif ($ModsCustom) {
+         Write-ToLog "-> Running (customizing default): Winget upgrade --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget -h --custom $ModsCustom"
+         & $Winget upgrade --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget --custom $ModsCustom | Where-Object { $_ -notlike "   *" } | Tee-Object -file $LogFile -Append
     }
     else {
         Write-ToLog "-> Running: Winget upgrade --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget -h"
@@ -64,6 +68,10 @@ Function Update-App ($app) {
             if ($ModsOverride) {
                 Write-ToLog "-> Running (overriding default): Winget install --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget --force --override $ModsOverride"
                 & $Winget install --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget --force --override $ModsOverride | Where-Object { $_ -notlike "   *" } | Tee-Object -file $LogFile -Append
+            }
+            elseif ($ModsCustom) {
+                 Write-ToLog "-> Running (customizing default): Winget install --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget -h --force --custom $ModsCustom"
+                 & $Winget upgrade --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget --custom $ModsCustom | Where-Object { $_ -notlike "   *" } | Tee-Object -file $LogFile -Append
             }
             else {
                 Write-ToLog "-> Running: Winget install --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget -h --force"

--- a/Sources/Winget-AutoUpdate/functions/Update-App.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Update-App.ps1
@@ -71,7 +71,7 @@ Function Update-App ($app) {
             }
             elseif ($ModsCustom) {
                  Write-ToLog "-> Running (customizing default): Winget install --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget -h --force --custom $ModsCustom"
-                 & $Winget upgrade --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget --custom $ModsCustom | Where-Object { $_ -notlike "   *" } | Tee-Object -file $LogFile -Append
+                 & $Winget install --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget --custom $ModsCustom | Where-Object { $_ -notlike "   *" } | Tee-Object -file $LogFile -Append
             }
             else {
                 Write-ToLog "-> Running: Winget install --id $($app.Id) -e --accept-package-agreements --accept-source-agreements -s winget -h --force"

--- a/Sources/Winget-AutoUpdate/mods/README.md
+++ b/Sources/Winget-AutoUpdate/mods/README.md
@@ -24,8 +24,11 @@ A script **Template** for an all-purpose mod (`_WAU-notinstalled-template.ps1`) 
 Name it `_WAU-notinstalled.ps1` for activation
 
 ### Winget native parameters:
-Another finess is the **AppID** followed by the `-override` suffix as a **text file** (**.txt**).
+Another finess is the **AppID** followed by the `-override` or `-custom` suffix as a **text file** (**.txt**).
 > Example:  
 >  **Canneverbe.CDBurnerXP-override.txt** with the content `ADDLOCAL=All REMOVE=Desktop_Shortcut /qn`
 
-This will use the **content** of the text file as a native **winget --override** parameter in **WAU upgrading**.
+> Example:  
+>  **ShareX.ShareX-custom.txt** with the content `/TASKS=!CreateDesktopIcon`
+
+This will use the **content** of the text file as a native **winget --override** respectively **winget --custom** parameter in **WAU upgrading**.

--- a/Sources/Winget-AutoUpdate/mods/README.md
+++ b/Sources/Winget-AutoUpdate/mods/README.md
@@ -29,6 +29,6 @@ Another finess is the **AppID** followed by the `-override` or `-custom` suffix 
 >  **Canneverbe.CDBurnerXP-override.txt** with the content `ADDLOCAL=All REMOVE=Desktop_Shortcut /qn`
 
 > Example:  
->  **ShareX.ShareX-custom.txt** with the content `/TASKS=!CreateDesktopIcon`
+>  **ShareX.ShareX-custom.txt** with the content `/MERGETASKS=!CreateDesktopIcon`
 
 This will use the **content** of the text file as a native **winget --override** respectively **winget --custom** parameter in **WAU upgrading**.


### PR DESCRIPTION
# Proposed Changes

Previously, `AppID-override.txt` allowed specifying parameters for `--override`.

**New functionality:**
The feature is replicated for the `--custom` parameter using `AppID-custom.txt`.
If `AppID-custom.txt exists`, its content will be added to the winget command as the value for `--custom`.

**Benefits:**
Extends flexibility by supporting custom configurations for winget operations at the application level.
Maintains consistency with the established approach for `--override`.

## Related Issues

> #796
