### PR TITLE
SymLinkCheck

### DIFF
--- a/Sources/Winget-AutoUpdate/Winget-Install.ps1
+++ b/Sources/Winget-AutoUpdate/Winget-Install.ps1
@@ -54,13 +54,21 @@ param(
 
 <# FUNCTIONS #>
 
-#Include external Functions
-. "$PSScriptRoot\functions\Install-Prerequisites.ps1"
-. "$PSScriptRoot\functions\Update-StoreApps.ps1"
-. "$PSScriptRoot\functions\Add-ScopeMachine.ps1"
-. "$PSScriptRoot\functions\Get-WingetCmd.ps1"
-. "$PSScriptRoot\functions\Write-ToLog.ps1"
-. "$PSScriptRoot\functions\Confirm-Installation.ps1"
+#Include external Functions (check first if this script is a symlink or a real file)
+$scriptItem = Get-Item -LiteralPath $MyInvocation.MyCommand.Definition
+$realPath = if ($scriptItem.LinkType) {
+    $targetPath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($scriptItem.Directory.FullName, $scriptItem.Target))
+    Split-Path -Parent $targetPath
+} else {
+    $scriptItem.DirectoryName
+}
+
+. "$realPath\functions\Install-Prerequisites.ps1"
+. "$realPath\functions\Update-StoreApps.ps1"
+. "$realPath\functions\Add-ScopeMachine.ps1"
+. "$realPath\functions\Get-WingetCmd.ps1"
+. "$realPath\functions\Write-ToLog.ps1"
+. "$realPath\functions\Confirm-Installation.ps1"
 
 
 #Check if App exists in Winget Repository


### PR DESCRIPTION
# Proposed Changes

Check if `Winget-Install.ps1` is a **SymLink** or not and get the real path of the file.
In this way those of us who have used the standalone script from https://github.com/Romanitho/Winget-Install over the years and placed the script under another path while configuring our **WinGet** installations in various deployments can replace the old script with the now in **WAU** implemented one via a **SymLink**!