### PR TITLE
implement semver comparison for winget version detection

### DIFF
--- a/Sources/Winget-AutoUpdate/functions/Compare-SemVer.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Compare-SemVer.ps1
@@ -1,0 +1,40 @@
+function Compare-SemVer {
+    param (
+        [string]$Version1,
+        [string]$Version2
+    )
+    
+    # Split version and pre-release parts
+    $v1Parts = $Version1 -split '-'
+    $v2Parts = $Version2 -split '-'
+    
+    $v1 = [Version]$v1Parts[0]
+    $v2 = [Version]$v2Parts[0]
+    
+    # Compare main version parts
+    if ($v1.Major -ne $v2.Major) {
+        return [Math]::Sign($v1.Major - $v2.Major)
+    }
+    if ($v1.Minor -ne $v2.Minor) {
+        return [Math]::Sign($v1.Minor - $v2.Minor)
+    }
+    if ($v1.Build -ne $v2.Build) {
+        return [Math]::Sign($v1.Build - $v2.Build)
+    }
+    if ($v1.Revision -ne $v2.Revision) {
+        return [Math]::Sign($v1.Revision - $v2.Revision)
+    }
+    
+    # Compare pre-release parts if they exist
+    if ($v1Parts.Length -eq 2 -and $v2Parts.Length -eq 2) {
+        return [String]::Compare($v1Parts[1], $v2Parts[1])
+    }
+    elseif ($v1Parts.Length -eq 2) {
+        return -1
+    }
+    elseif ($v2Parts.Length -eq 2) {
+        return 1
+    }
+    
+    return 0
+}

--- a/Sources/Winget-AutoUpdate/functions/Install-Prerequisites.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Install-Prerequisites.ps1
@@ -88,7 +88,7 @@ function Install-Prerequisites {
         try {
             #Get latest WinGet info
             $WinGeturl = 'https://api.github.com/repos/microsoft/winget-cli/releases/latest'
-            $WinGetAvailableVersion = ((Invoke-WebRequest $WinGeturl -UseBasicParsing | ConvertFrom-Json)[0].tag_name).Replace("v", "")
+            $WinGetAvailableVersion = ((Invoke-WebRequest $WinGeturl -UseBasicParsing | ConvertFrom-Json)[0].tag_name).TrimStart("v")
         }
         catch {
             #if fail set version to the latest version as of 2024-04-29
@@ -100,13 +100,14 @@ function Install-Prerequisites {
             #If multiple versions, pick most recent one
             $WingetCmd = $WingetInfo[-1].FileName
             #Get current Winget Version
-            $WingetInstalledVersion = (& $WingetCmd -v).Replace("v", "").trim()
+            $WingetInstalledVersion = (& $WingetCmd -v).Trim().TrimStart("v")
         }
         catch {
             Write-ToLog "WinGet is not installed" "Red"
         }
-        #Check if the current available WinGet is newer than the installed
-        if ($WinGetAvailableVersion -gt $WinGetInstalledVersion) {
+        Write-ToLog "WinGet installed version: $WinGetInstalledVersion | WinGet available version: $WinGetAvailableVersion"
+        #Check if the currently installed version is less than the available version
+        if ((Compare-SemVer -Version1 $WinGetInstalledVersion -Version2 $WinGetAvailableVersion) -lt 0) {
             #Install WinGet MSIXBundle in SYSTEM context
             try {
                 #Download WinGet MSIXBundle


### PR DESCRIPTION
# Proposed Changes

## SemVer version comparison
Switch to actual [SemVer](https://semver.org/) version comparison for the available / installed version detection.
 WinGet distributes "-preview" versions for participants of the insider program which currently isn't supported by the version comparison. This causes WAU to fully download and install an older WinGet version on every run even though the preview version is actually newer. 

```PS
$WinGetAvailableVersion = "1.9.25200"
$WinGetInstalledVersion = "1.10.40-preview"

$WinGetAvailableVersion -gt $WinGetInstalledVersion
-> True (wrong)

Compare-SemVer -Version1 $WinGetAvailableVersion -Version2 $WinGetInstalledVersion
-> -1 (available is lower then the currently installed version)

$WinGetAvailableVersion = "1.10.40"
$WinGetInstalledVersion = "1.10.40-preview"
Compare-SemVer -Version1 $WinGetAvailableVersion -Version2 $WinGetInstalledVersion
-> 1 (available is greater then the currently installed version -> correct)

$WinGetAvailableVersion = "1.9.25200"
$WinGetInstalledVersion = "1.8.0"
Compare-SemVer -Version1 $WinGetAvailableVersion -Version2 $WinGetInstalledVersion
-> 1 (available is greater then the currently installed version -> correct)

$WinGetAvailableVersion = "1.9.25200"
$WinGetInstalledVersion = "1.9.25200"
Compare-SemVer -Version1 $WinGetAvailableVersion -Version2 $WinGetInstalledVersion
-> 0 (available is equal to the currently installed version -> correct)
```

## replace `Replace` with `TrimStart`
`v1.10.40-preview` was currently detected as `1.10.40-preiew` due to `Replace("v", "")`.  
`TrimStart("v")` fixes this.



