### PR TITLE
Update Get-WingetCmd.ps1

### DIFF
--- a/Sources/Winget-AutoUpdate/functions/Get-WingetCmd.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Get-WingetCmd.ps1
@@ -10,7 +10,7 @@ Function Get-WingetCmd {
 
     #default winget path (in user context)
     [string]$pu = "$env:LocalAppData\Microsoft\WindowsApps\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\winget.exe";
-    
+
     try {
         #Get Admin Context Winget Location
         $WingetInfo = (Get-Item -Path $ps -ErrorAction Stop).VersionInfo | Sort-Object -Property FileVersionRaw -Descending | Select-Object -First 1;

--- a/Sources/Winget-AutoUpdate/functions/Get-WingetCmd.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Get-WingetCmd.ps1
@@ -4,14 +4,14 @@ Function Get-WingetCmd {
     [OutputType([String])]
 
     $WingetCmd = [string]::Empty;
-    try {
     #Get WinGet Path
     # default winget path (in system context)
     [string]$ps = "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_8wekyb3d8bbwe\winget.exe";
 
     #default winget path (in user context)
     [string]$pu = "$env:LocalAppData\Microsoft\WindowsApps\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\winget.exe";
-
+    
+    try {
         #Get Admin Context Winget Location
         $WingetInfo = (Get-Item -Path $ps -ErrorAction Stop).VersionInfo | Sort-Object -Property FileVersionRaw -Descending | Select-Object -First 1;
         #If multiple versions, pick most recent one

--- a/Sources/Winget-AutoUpdate/functions/Get-WingetCmd.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Get-WingetCmd.ps1
@@ -2,8 +2,9 @@
 
 Function Get-WingetCmd {
     [OutputType([String])]
-    $WingetCmd = [string]::Empty;
 
+    $WingetCmd = [string]::Empty;
+    try {
     #Get WinGet Path
     # default winget path (in system context)
     [string]$ps = "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_8wekyb3d8bbwe\winget.exe";
@@ -11,9 +12,8 @@ Function Get-WingetCmd {
     #default winget path (in user context)
     [string]$pu = "$env:LocalAppData\Microsoft\WindowsApps\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\winget.exe";
 
-    try {
         #Get Admin Context Winget Location
-        $WingetInfo = (Get-Item -Path $ps).VersionInfo | Sort-Object -Property FileVersionRaw -Descending | Select-Object -First 1;
+        $WingetInfo = (Get-Item -Path $ps -ErrorAction Stop).VersionInfo | Sort-Object -Property FileVersionRaw -Descending | Select-Object -First 1;
         #If multiple versions, pick most recent one
         $WingetCmd = $WingetInfo.FileName;
     }


### PR DESCRIPTION
# Proposed Changes

> Missing failsafe when winget does not exist in system context (trigger for fallback to instance in the user context). Addendum to logic changed in PR #789

## Related Issues
#789
