### PR TITLE
Update Install-Prerequisites.ps1

### DIFF
--- a/Sources/Winget-AutoUpdate/functions/Install-Prerequisites.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Install-Prerequisites.ps1
@@ -1,152 +1,89 @@
 function Install-Prerequisites {
+	
+	try {
 
-    try {
+		Write-ToLog "Checking prerequisites..." "Yellow"
 
-        Write-ToLog "Checking prerequisites..." "Yellow"
+		if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
+			$OSArch = "arm64"
+		}
+		elseif ($env:PROCESSOR_ARCHITECTURE -like "*64*") {
+			$OSArch = "x64"
+		}
+		else {
+			$OSArch = "x86"
+		}
 
-        #Check if Visual C++ 2022 is installed
-        $Visual2022 = "Microsoft Visual C++ 2015-2022 Redistributable*"
-        $VisualMinVer = "14.40.0.0"
-        $path = Get-Item HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*, HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { $_.GetValue("DisplayName") -like $Visual2022 -and $_.GetValue("DisplayVersion") -gt $VisualMinVer }
-        if (!($path)) {
-            try {
-                Write-ToLog "MS Visual C++ 2015-2022 is not installed" "Red"
+		$ProgressPreference = "SilentlyContinue"
+		$Path = "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_8wekyb3d8bbwe\winget.exe"
+		$Item = Get-Item -Path $Path
+		$InstalledVersion = "0.0"
 
-                #Get proc architecture
-                if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
-                    $OSArch = "arm64"
-                }
-                elseif ($env:PROCESSOR_ARCHITECTURE -like "*64*") {
-                    $OSArch = "x64"
-                }
-                else {
-                    $OSArch = "x86"
-                }
+		if ($Item) {
+			$Info = $Item.VersionInfo |
+			Sort-Object -Property FileVersionRaw -Descending -Unique |
+			Select-Object -First 1
+			$Cmd = $Info.FileName
+			$InstalledVersion = (& $Cmd -v | Select-String -Pattern '[\d\.]+').Matches.Value
+		}
 
-                #Download and install
-                $SourceURL = "https://aka.ms/vs/17/release/VC_redist.$OSArch.exe"
-                $Installer = "$env:TEMP\VC_redist.$OSArch.exe"
-                Write-ToLog "-> Downloading $SourceURL..."
-                Invoke-WebRequest $SourceURL -OutFile $Installer -UseBasicParsing
-                Write-ToLog "-> Installing VC_redist.$OSArch.exe..."
-                Start-Process -FilePath $Installer -Args "/quiet /norestart" -Wait
-                Write-ToLog "-> MS Visual C++ 2015-2022 installed successfully." "Green"
-            }
-            catch {
-                Write-ToLog "-> MS Visual C++ 2015-2022 installation failed." "Red"
-            }
-            finally {
-                Remove-Item $Installer -ErrorAction Ignore
-            }
-        }
+		$urlBase = "microsoft/winget-cli/releases"
 
-        #Check if Microsoft.VCLibs.140.00.UWPDesktop is installed
-        if (!(Get-AppxPackage -Name 'Microsoft.VCLibs.140.00.UWPDesktop' -AllUsers)) {
-            try {
-                Write-ToLog "Microsoft.VCLibs.140.00.UWPDesktop is not installed" "Red"
-                #Download
-                $VCLibsUrl = "https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx"
-                $VCLibsFile = "$env:TEMP\Microsoft.VCLibs.x64.14.00.Desktop.appx"
-                Write-ToLog "-> Downloading Microsoft.VCLibs.140.00.UWPDesktop..."
-                Invoke-WebRequest -Uri $VCLibsUrl -OutFile $VCLibsFile -UseBasicParsing
-                #Install
-                Write-ToLog "-> Installing Microsoft.VCLibs.140.00.UWPDesktop..."
-                Add-AppxProvisionedPackage -Online -PackagePath $VCLibsFile -SkipLicense | Out-Null
-                Write-ToLog "-> Microsoft.VCLibs.140.00.UWPDesktop installed successfully." "Green"
-            }
-            catch {
-                Write-ToLog "-> Failed to install Microsoft.VCLibs.140.00.UWPDesktop..." "Red"
-            }
-            finally {
-                Remove-Item -Path $VCLibsFile -Force
-            }
-        }
+		$AvailableVersion = (((Invoke-WebRequest -Uri "https://api.github.com/repos/$urlBase/latest" |
+					ConvertFrom-Json).tag_name) | Select-String '[\d\.]+').Matches.Value
 
-        #Check if Microsoft.UI.Xaml.2.8 is installed
-        if (!(Get-AppxPackage -Name 'Microsoft.UI.Xaml.2.8' -AllUsers)) {
-            try {
-                Write-ToLog "Microsoft.UI.Xaml.2.8 is not installed" "Red"
-                #Download
-                $UIXamlUrl = "https://github.com/microsoft/microsoft-ui-xaml/releases/download/v2.8.6/Microsoft.UI.Xaml.2.8.x64.appx"
-                $UIXamlFile = "$env:TEMP\Microsoft.UI.Xaml.2.8.x64.appx"
-                Write-ToLog "-> Downloading Microsoft.UI.Xaml.2.8..."
-                Invoke-WebRequest -Uri $UIXamlUrl -OutFile $UIXamlFile -UseBasicParsing
-                #Install
-                Write-ToLog "-> Installing Microsoft.UI.Xaml.2.8..."
-                Add-AppxProvisionedPackage -Online -PackagePath $UIXamlFile -SkipLicense | Out-Null
-                Write-ToLog "-> Microsoft.UI.Xaml.2.8 installed successfully." "Green"
-            }
-            catch {
-                Write-ToLog "-> Failed to install Microsoft.UI.Xaml.2.8..." "Red"
-            }
-            finally {
-                Remove-Item -Path $UIXamlFile -Force
-            }
-        }
+		# $AvailableVersion = [System.Version]::Parse($AvailableVersion)
+		# $InstalledVersion = [System.Version]::Parse($InstalledVersion)
 
-        #Check if Winget is installed (and up to date)
-        try {
-            #Get latest WinGet info
-            $WinGeturl = 'https://api.github.com/repos/microsoft/winget-cli/releases/latest'
-            $WinGetAvailableVersion = ((Invoke-WebRequest $WinGeturl -UseBasicParsing | ConvertFrom-Json)[0].tag_name).Replace("v", "")
-        }
-        catch {
-            #if fail set version to the latest version as of 2024-04-29
-            $WinGetAvailableVersion = "1.7.11132"
-        }
-        try {
-            #Get Admin Context Winget Location
-            $WingetInfo = (Get-Item "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_8wekyb3d8bbwe\winget.exe").VersionInfo | Sort-Object -Property FileVersionRaw
-            #If multiple versions, pick most recent one
-            $WingetCmd = $WingetInfo[-1].FileName
-            #Get current Winget Version
-            $WingetInstalledVersion = (& $WingetCmd -v).Replace("v", "").trim()
-        }
-        catch {
-            Write-ToLog "WinGet is not installed" "Red"
-        }
-        #Check if the current available WinGet is newer than the installed
-        if ($WinGetAvailableVersion -gt $WinGetInstalledVersion) {
-            #Install WinGet MSIXBundle in SYSTEM context
-            try {
-                #Download WinGet MSIXBundle
-                Write-ToLog "-> Downloading WinGet MSIXBundle for App Installer..."
-                $WinGetURL = "https://github.com/microsoft/winget-cli/releases/download/v$WinGetAvailableVersion/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle"
-                $WingetInstaller = "$env:TEMP\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle"
-                Invoke-WebRequest -Uri $WinGetURL -OutFile $WingetInstaller -UseBasicParsing
+		if ($InstalledVersion -eq "0.0") {
 
-                #Install
-                Write-ToLog "-> Installing WinGet MSIXBundle for App Installer..."
-                Add-AppxProvisionedPackage -Online -PackagePath $WingetInstaller -SkipLicense | Out-Null
-                Write-ToLog "-> WinGet MSIXBundle (v$WinGetAvailableVersion) for App Installer installed successfully!" "green"
+			$url = "https://github.com/$urlBase/download/v$AvailableVersion"
+			$urlDependencies = "$url/DesktopAppInstaller_Dependencies"
 
-                #Reset WinGet Sources
-                $WingetInfo = (Get-Item "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_8wekyb3d8bbwe\winget.exe").VersionInfo | Sort-Object -Property FileVersionRaw
-                #If multiple versions, pick most recent one
-                $WingetCmd = $WingetInfo[-1].FileName
-                & $WingetCmd source reset --force
-                Write-ToLog "-> WinGet sources reset." "green"
-            }
-            catch {
-                Write-ToLog "-> Failed to install WinGet MSIXBundle for App Installer..." "red"
-                #Force Store Apps to update
-                Update-StoreApps
-            }
+			$Installer = "$env:TEMP\DesktopAppInstaller_Dependencies"
+			Invoke-WebRequest -Uri "$urlDependencies.zip" -OutFile "$Installer.zip"
+			Expand-Archive -Path "$Installer.zip" -DestinationPath $Installer -Force
 
-            #Remove WinGet MSIXBundle
-            Remove-Item -Path $WingetInstaller -Force -ErrorAction SilentlyContinue
-        }
-        else {
-            Write-ToLog "-> WinGet is up to date: v$WinGetInstalledVersion" "Green"
-        }
-        Write-ToLog "Prerequisites checked. OK" "Green"
+			$Dependencies = Invoke-WebRequest -Uri "$urlDependencies.json" | ConvertFrom-Json
+		
+			$Dependencies.Dependencies | ForEach-Object {
 
-    }
-    catch {
+				$Package = Get-AppxPackage -Name $_.Name -AllUsers |
+				Where-Object { $_.PackageUserInformation -match "Installed" }
+			
+				if (!$Package) {
 
-        Write-ToLog "Prerequisites checked failed" "Red"
+					$Package = (Get-Item -Path "$Installer/$OSArch/$($_.Name)*").FullName
+					Add-AppxProvisionedPackage -Online -PackagePath $Package -SkipLicense | Out-Null
+				}
+			}
 
-    }
+			Remove-Item -Path "$Installer*" -Recurse -Force
 
+			$msixbundle = "Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle"
+			Invoke-WebRequest -Uri "$url/$msixbundle" -OutFile "$env:TEMP\$msixbundle"
+			Add-AppxProvisionedPackage -Online -PackagePath "$env:TEMP\$msixbundle" -SkipLicense | Out-Null
+			Remove-Item -Path "$env:TEMP\$msixbundle" -Force
+		}
 
+		$WingetInfo = (Get-Item "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_8wekyb3d8bbwe\winget.exe").VersionInfo |
+		Sort-Object -Property FileVersionRaw -Descending -Unique | Select-Object -First 1
+		$WingetCmd = $WingetInfo.FileName
+
+		& $WingetCmd upgrade --all --accept-package-agreements --accept-source-agreements --disable-interactivity --silent
+
+		$Visual2022 = Get-CimInstance -ClassName "Win32_Product" | Where-Object Name -Like "Microsoft Visual C++ * $OSArch*"
+	
+		if (!$Visual2022) {
+			& $WingetCmd install --id "Microsoft.VCRedist.2015+.$OSArch" --source "winget" --scope "machine" --disable-interactivity --silent
+		}
+
+		$ProgressPreference = "Continue"
+
+	}
+	catch {
+
+		Write-ToLog "Prerequisites checked failed" "Red"
+
+	}
 }

--- a/Sources/Winget-AutoUpdate/functions/Install-Prerequisites.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Install-Prerequisites.ps1
@@ -3,6 +3,7 @@ function Install-Prerequisites {
 	try {
 
 		Write-ToLog "Checking prerequisites..." "Yellow"
+		$ProgressPreference = "SilentlyContinue"
 
 		if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") {
 			$OSArch = "arm64"
@@ -14,10 +15,10 @@ function Install-Prerequisites {
 			$OSArch = "x86"
 		}
 
-		$ProgressPreference = "SilentlyContinue"
+		$InstalledVersion = "0.0"
+
 		$Path = "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_8wekyb3d8bbwe\winget.exe"
 		$Item = Get-Item -Path $Path
-		$InstalledVersion = "0.0"
 
 		if ($Item) {
 			$Info = $Item.VersionInfo |
@@ -25,17 +26,16 @@ function Install-Prerequisites {
 			Select-Object -First 1
 			$Cmd = $Info.FileName
 			$InstalledVersion = (& $Cmd -v | Select-String -Pattern '[\d\.]+').Matches.Value
+			$InstalledVersion = [System.Version]::Parse($InstalledVersion)
 		}
 
-		$urlBase = "microsoft/winget-cli/releases"
-
-		$AvailableVersion = (((Invoke-WebRequest -Uri "https://api.github.com/repos/$urlBase/latest" |
-					ConvertFrom-Json).tag_name) | Select-String '[\d\.]+').Matches.Value
-
-		# $AvailableVersion = [System.Version]::Parse($AvailableVersion)
-		# $InstalledVersion = [System.Version]::Parse($InstalledVersion)
-
 		if ($InstalledVersion -eq "0.0") {
+
+			$urlBase = "microsoft/winget-cli/releases"
+
+			$AvailableVersion = (((Invoke-WebRequest -Uri "https://api.github.com/repos/$urlBase/latest" |
+						ConvertFrom-Json).tag_name) | Select-String '[\d\.]+').Matches.Value
+			# $AvailableVersion = [System.Version]::Parse($AvailableVersion)
 
 			$url = "https://github.com/$urlBase/download/v$AvailableVersion"
 			$urlDependencies = "$url/DesktopAppInstaller_Dependencies"


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

- improves the check if the winget in preview version is installed

     previewVersion -> v1.10.40-preview
     old
      `(& $WingetCmd -v).Replace("v", "").trim()`
 
     new
     `(& $Cmd -v | Select-String -Pattern '[\d\.]+').Matches.Value`
     but no longer necessary as it only checks whether it is installed or not

- download only one package of dependencies and not separate for VCLibs / UI.Xaml

     links are hard-coded, which may pose a problem in the future

- Microsoft Visual C++ Redistributable

     another method to check if MSVCR is installed via
     `Get-CimInstance -ClassName "Win32_Product"`

     downloads
     link "https://aka.ms/vs/17/release/VC_redist.$OSArch.exe"
     more elegant method install via winget at end of this script / function
     `winget install --id "Microsoft.VCRedist.2015+.$OSArch"`

- improve `Invoke-WebRequest `

     `-UseBasicParsing` / deprecated

     don't show progressbar
     `$ProgressPreference = "SilentlyContinue"`
     `$ProgressPreference = "Continue"`

- why reinstall winget if the installed version is lower when it can update itself?

     `winget upgrade --id Microsoft.AppInstaller`

- what is the point of reset the source if winget is already installed. you don't know if other important sources have been added.

     `& $WingetCmd source reset --force`

- please can you add comments and write to log.
     I don't know what makes sense or if there are too many. Thank you