### PR TITLE
New Feature: Select Day of Week

### DIFF
--- a/Sources/Policies/ADMX/WAU.admx
+++ b/Sources/Policies/ADMX/WAU.admx
@@ -420,5 +420,48 @@
         <text id="WingetSourceCustom" valueName="WAU_WingetSourceCustom" />
       </elements>
     </policy>
+    <policy name="DayofWeek_Enable" class="Machine" displayName="$(string.DayofWeek_Name)" explainText="$(string.DayofWeek_Explain)" key="Software\Policies\Romanitho\Winget-AutoUpdate"  presentation="$(presentation.DayofWeek)">
+      <parentCategory ref="WAU"/>
+      <supportedOn ref="WAU:SUPPORTED_WAU_1_16_0"/>
+      <elements>
+        <enum id="DayofWeek" valueName="WAU_DayofWeek">
+          <item displayName="$(string.DayofWeek_Monday)">
+            <value>
+              <string>Monday</string>
+            </value>
+          </item>
+          <item displayName="$(string.DayofWeek_Tuesday)">
+            <value>
+              <string>Tuesday</string>
+            </value>
+          </item>
+          <item displayName="$(string.DayofWeek_Wednesday)">
+            <value>
+              <string>Wednesday</string>
+            </value>
+          </item>
+          <item displayName="$(string.DayofWeek_Thursday)">
+            <value>
+              <string>Thursday</string>
+            </value>
+          </item>
+          <item displayName="$(string.DayofWeek_Friday)">
+            <value>
+              <string>Friday</string>
+            </value>
+          </item>
+          <item displayName="$(string.DayofWeek_Saturday)">
+            <value>
+              <string>Saturday</string>
+            </value>
+          </item>
+          <item displayName="$(string.DayofWeek_Sunday)">
+            <value>
+              <string>Sunday</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
   </policies>
 </policyDefinitions>

--- a/Sources/Policies/ADMX/WAU.admx
+++ b/Sources/Policies/ADMX/WAU.admx
@@ -422,7 +422,7 @@
     </policy>
     <policy name="DayofWeek_Enable" class="Machine" displayName="$(string.DayofWeek_Name)" explainText="$(string.DayofWeek_Explain)" key="Software\Policies\Romanitho\Winget-AutoUpdate"  presentation="$(presentation.DayofWeek)">
       <parentCategory ref="WAU"/>
-      <supportedOn ref="WAU:SUPPORTED_WAU_1_16_0"/>
+      <supportedOn ref="WAU:SUPPORTED_WAU_1_16_5"/>
       <elements>
         <enum id="DayofWeek" valueName="WAU_DayofWeek">
           <item displayName="$(string.DayofWeek_Monday)">

--- a/Sources/Policies/ADMX/en-US/WAU.adml
+++ b/Sources/Policies/ADMX/en-US/WAU.adml
@@ -107,6 +107,24 @@
       <string id="UpdatesInterval_Monthly">5. Monthly</string>
       <string id="UpdatesInterval_Never">6. Never (e.g. in combination with 'Updates
         Interval')</string>
+      <string id="DayofWeek_Name">Updates Day of Week (e.g. in combination with 'Updates Interval Weekly')</string>
+      <string id="DayofWeek_Explain">If this policy is enabled, you can configure the day of the week updates are run:
+1. Monday (Default)
+2. Tuesday
+3. Wednesday
+4. Thursday
+5. Friday
+6. Saturday
+7. Sunday
+
+If this policy is not configured or disabled, the default day is Monday.</string>
+      <string id="DayofWeek_Monday">1. Monday (Default)</string>
+      <string id="DayofWeek_Tuesday">2. Tuesday</string>
+      <string id="DayofWeek_Wednesday">3. Wednesday</string>
+      <string id="DayofWeek_Thursday">4. Thursday</string>
+      <string id="DayofWeek_Friday">5. Friday</string>
+      <string id="DayofWeek_Saturday">6. Saturday</string>
+      <string id="DayofWeek_Sunday">7. Sunday</string>
       <string id="UpdatesAtLogon_Name">Updates at Logon</string>
       <string id="UpdatesAtLogon_Explain">This policy setting specifies whether to set
         WAU to run at user logon or not.
@@ -213,6 +231,9 @@
       </presentation>
       <presentation id="UpdatesInterval">
         <dropdownList refId="UpdatesInterval" />
+      </presentation>
+      <presentation id="DayofWeek">
+        <dropdownList refId="DayofWeek"/>
       </presentation>
       <presentation id="UpdatesAtTime">
         <dropdownList refId="UpdatesAtTime" />

--- a/Sources/Policies/ADMX/en-US/WAU.adml
+++ b/Sources/Policies/ADMX/en-US/WAU.adml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="4.8" schemaVersion="1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="4.9" schemaVersion="1.0"
   xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <displayName>WinGet-AutoUpdate</displayName>
   <description>WinGet-AutoUpdate GPO Management</description>

--- a/Sources/Policies/ADMX/fr-FR/WAU.adml
+++ b/Sources/Policies/ADMX/fr-FR/WAU.adml
@@ -265,6 +265,9 @@ Si cette stratégie n'est pas configurée ou est désactivée, le jour par défa
       <presentation id="UpdatesInterval">
         <dropdownList refId="UpdatesInterval" />
       </presentation>
+      <presentation id="DayofWeek">
+        <dropdownList refId="DayofWeek"/>
+      </presentation>
       <presentation id="UpdatesAtTime">
         <dropdownList refId="UpdatesAtTime" />
       </presentation>

--- a/Sources/Policies/ADMX/fr-FR/WAU.adml
+++ b/Sources/Policies/ADMX/fr-FR/WAU.adml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="4.8" schemaVersion="1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="4.9" schemaVersion="1.0"
   xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <displayName>WinGet-AutoUpdate</displayName>
   <description>Gestion GPO de WinGet-AutoUpdate</description>

--- a/Sources/Policies/ADMX/fr-FR/WAU.adml
+++ b/Sources/Policies/ADMX/fr-FR/WAU.adml
@@ -126,6 +126,24 @@
       <string id="UpdatesInterval_Monthly">5. Mensuel</string>
       <string id="UpdatesInterval_Never">6. Jamais (par exemple, en combinaison avec 'Intervalle de
         mise à jour')</string>
+      <string id="DayofWeek_Name">Jour des mises à jour (par exemple, en combinaison avec 'Intervalle des mises à jour hebdomadaire')</string>
+      <string id="DayofWeek_Explain">Si cette stratégie est activée, vous pouvez configurer le jour de la semaine où les mises à jour sont effectuées :
+1. Lundi (Par défaut)
+2. Mardi
+3. Mercredi
+4. Jeudi
+5. Vendredi
+6. Samedi
+7. Dimanche
+
+Si cette stratégie n'est pas configurée ou est désactivée, le jour par défaut est le lundi.</string>
+      <string id="DayofWeek_Monday">1. Lundi (Par défaut)</string>
+      <string id="DayofWeek_Tuesday">2. Mardi</string>
+      <string id="DayofWeek_Wednesday">3. Mercredi</string>
+      <string id="DayofWeek_Thursday">4. Jeudi</string>
+      <string id="DayofWeek_Friday">5. Vendredi</string>
+      <string id="DayofWeek_Saturday">6. Samedi</string>
+      <string id="DayofWeek_Sunday">7. Dimanche</string>
       <string id="UpdatesAtLogon_Name">Mises à jour à la connexion</string>
       <string id="UpdatesAtLogon_Explain">
         Ce paramètre de politique spécifie s'il faut configurer WAU pour s'exécuter à la connexion

--- a/Sources/Winget-AutoUpdate/WAU-Policies.ps1
+++ b/Sources/Winget-AutoUpdate/WAU-Policies.ps1
@@ -51,10 +51,18 @@ if ($WAUConfig.WAU_RunGPOManagement -eq 1) {
         $tasktriggers += New-ScheduledTaskTrigger -Daily -At $WAUConfig.WAU_UpdatesAtTime -DaysInterval 2
     }
     elseif ($WAUConfig.WAU_UpdatesInterval -eq "Weekly") {
-        $tasktriggers += New-ScheduledTaskTrigger -Weekly -At $WAUConfig.WAU_UpdatesAtTime -DaysOfWeek 2
+        if ($WAUConfig.WAU_DayofWeek) {
+            $tasktriggers += New-ScheduledTaskTrigger -Weekly -At $WAUConfig.WAU_UpdatesAtTime -DaysOfWeek $WAUConfig.WAU_DayofWeek
+        } else {
+            $tasktriggers += New-ScheduledTaskTrigger -Weekly -At $WAUConfig.WAU_UpdatesAtTime -DaysOfWeek 2
+        }
     }
     elseif ($WAUConfig.WAU_UpdatesInterval -eq "BiWeekly") {
-        $tasktriggers += New-ScheduledTaskTrigger -Weekly -At $WAUConfig.WAU_UpdatesAtTime -DaysOfWeek 2 -WeeksInterval 2
+        if ($WAUConfig.WAU_DayofWeek) {
+        $tasktriggers += New-ScheduledTaskTrigger -Weekly -At $WAUConfig.WAU_UpdatesAtTime -DaysOfWeek $WAUConfig.WAU_DayofWeek -WeeksInterval 2
+        } else {
+            $tasktriggers += New-ScheduledTaskTrigger -Weekly -At $WAUConfig.WAU_UpdatesAtTime -DaysOfWeek 2 -WeeksInterval 2
+        }
     }
     elseif ($WAUConfig.WAU_UpdatesInterval -eq "Monthly") {
         $tasktriggers += New-ScheduledTaskTrigger -Weekly -At $WAUConfig.WAU_UpdatesAtTime -DaysOfWeek 2 -WeeksInterval 4

--- a/Sources/Winget-AutoUpdate/WAU-Policies.ps1
+++ b/Sources/Winget-AutoUpdate/WAU-Policies.ps1
@@ -59,13 +59,17 @@ if ($WAUConfig.WAU_RunGPOManagement -eq 1) {
     }
     elseif ($WAUConfig.WAU_UpdatesInterval -eq "BiWeekly") {
         if ($WAUConfig.WAU_DayofWeek) {
-        $tasktriggers += New-ScheduledTaskTrigger -Weekly -At $WAUConfig.WAU_UpdatesAtTime -DaysOfWeek $WAUConfig.WAU_DayofWeek -WeeksInterval 2
+            $tasktriggers += New-ScheduledTaskTrigger -Weekly -At $WAUConfig.WAU_UpdatesAtTime -DaysOfWeek $WAUConfig.WAU_DayofWeek -WeeksInterval 2
         } else {
             $tasktriggers += New-ScheduledTaskTrigger -Weekly -At $WAUConfig.WAU_UpdatesAtTime -DaysOfWeek 2 -WeeksInterval 2
         }
     }
     elseif ($WAUConfig.WAU_UpdatesInterval -eq "Monthly") {
-        $tasktriggers += New-ScheduledTaskTrigger -Weekly -At $WAUConfig.WAU_UpdatesAtTime -DaysOfWeek 2 -WeeksInterval 4
+        if ($WAUConfig.WAU_DayofWeek) {
+            $tasktriggers += New-ScheduledTaskTrigger -Weekly -At $WAUConfig.WAU_UpdatesAtTime -DaysOfWeek $WAUConfig.WAU_DayofWeek -WeeksInterval 4
+        } else {
+            $tasktriggers += New-ScheduledTaskTrigger -Weekly -At $WAUConfig.WAU_UpdatesAtTime -DaysOfWeek 2 -WeeksInterval 4
+        }
     }
     #If trigger(s) set
     if ($taskTriggers) {


### PR DESCRIPTION
# Proposed Changes

"Day of Week" feature. This allows you to specify the day of the week updates are run on using the Weekly or Bi-Weekly policy. If the Weekly or Bi-Weekly policy is selected, the policy script will check the DayofWeek registry value and update the schedule task appropriately. I also updated the ADMX and both English and French ADML files to allow for the new change. 

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
