### PR TITLE
Fix for if WinGet is not installed at all

### DIFF
--- a/Sources/Winget-AutoUpdate/functions/Install-Prerequisites.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Install-Prerequisites.ps1
@@ -104,6 +104,7 @@ function Install-Prerequisites {
         }
         catch {
             Write-ToLog "WinGet is not installed" "Red"
+            $WinGetInstalledVersion = "0.0.0"
         }
         Write-ToLog "WinGet installed version: $WinGetInstalledVersion | WinGet available version: $WinGetAvailableVersion"
         #Check if the currently installed version is less than the available version


### PR DESCRIPTION
# Proposed Changes

Compare-SemVer must have a value
Now set to 0,0,0 if WinGet doesn't exist (WSB/fresh installed clients)