### PR TITLE
Get-Content TRIM for -override/-custom

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can update only pre-selected apps. To do so, create an "included_apps.txt" w
 > The lists can contain Wildcard (*). For instance ```Mozilla.Firefox*``` will take care of all Firefox channels.
 
 List and Mods folder content will be copied to WAU install location:  
-![image](https://github.com/user-attachments/assets/f0ec4047-d66c-4277-a39c-763fd7516ad8)
+![image](https://private-user-images.githubusercontent.com/96626929/423074783-a37837b0-b61e-4ce7-b23c-fd8661585e40.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDIwMzUyNTYsIm5iZiI6MTc0MjAzNDk1NiwicGF0aCI6Ii85NjYyNjkyOS80MjMwNzQ3ODMtYTM3ODM3YjAtYjYxZS00Y2U3LWIyM2MtZmQ4NjYxNTg1ZTQwLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTAzMTUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwMzE1VDEwMzU1NlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTNiNTBjYTg3YTZhYTY3MDZiOTAwMmVhYmY0NzRlMWJkYjdjNjhhMmU3OGZkZDMxMmNlOTUzMTBlNWU5ZDg0NGMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.Gs1Hg3n3qNwwgRlPSWWNDi5yJbZwlG0yMdBNTx3_U1o)
 
 ### Notification Level
 You can choose which notification will be displayed: `Full`, `Success only` or `None`.

--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ You can use [Winget-Install](https://github.com/Romanitho/Winget-AutoUpdate/blob
 **Mods for WAU** allows you to craft a script to do whatever you like via `_WAU-mods.ps1` in the **mods** folder.<br>
 This script executes **if the network is active/any version of Winget is installed/WAU is running as SYSTEM**.<br>
 If **ExitCode** is **1** from `_WAU-mods.ps1` then **Re-run WAU**.
+
+Likewise `_WAU-mods-postsys.ps1` can be used to do things at the end of the **SYSTEM context WAU** process.
+
 ## Custom scripts (Mods feature for Apps)
 The Mods feature allows you to run additional scripts when upgrading or installing an app.
 Just put the scripts in question with the **AppID** followed by the `-preinstall`, `-upgrade`, `-install`, `-installed` or `-notinstalled` suffix in the **mods** folder.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ You can use [Winget-Install](https://github.com/Romanitho/Winget-AutoUpdate/blob
 This script executes **if the network is active/any version of Winget is installed/WAU is running as SYSTEM**.<br>
 If **ExitCode** is **1** from `_WAU-mods.ps1` then **Re-run WAU**.
 
-Likewise `_WAU-mods-postsys.ps1` can be used to do things at the end of the **SYSTEM context WAU** process.
+Likewise `_WAU-mods-postsys.ps1` can be used to do things at the end of the **SYSTEM context WAU** process before the user run.
 
 ## Custom scripts (Mods feature for Apps)
 The Mods feature allows you to run additional scripts when upgrading or installing an app.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can update only pre-selected apps. To do so, create an "included_apps.txt" w
 > The lists can contain Wildcard (*). For instance ```Mozilla.Firefox*``` will take care of all Firefox channels.
 
 List and Mods folder content will be copied to WAU install location:  
-![image](https://private-user-images.githubusercontent.com/96626929/423074783-a37837b0-b61e-4ce7-b23c-fd8661585e40.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDIwMzUyNTYsIm5iZiI6MTc0MjAzNDk1NiwicGF0aCI6Ii85NjYyNjkyOS80MjMwNzQ3ODMtYTM3ODM3YjAtYjYxZS00Y2U3LWIyM2MtZmQ4NjYxNTg1ZTQwLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTAzMTUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwMzE1VDEwMzU1NlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTNiNTBjYTg3YTZhYTY3MDZiOTAwMmVhYmY0NzRlMWJkYjdjNjhhMmU3OGZkZDMxMmNlOTUzMTBlNWU5ZDg0NGMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.Gs1Hg3n3qNwwgRlPSWWNDi5yJbZwlG0yMdBNTx3_U1o)
+![image](https://github.com/user-attachments/assets/f0ec4047-d66c-4277-a39c-763fd7516ad8)
 
 ### Notification Level
 You can choose which notification will be displayed: `Full`, `Success only` or `None`.

--- a/Sources/Winget-AutoUpdate/Winget-Install.ps1
+++ b/Sources/Winget-AutoUpdate/Winget-Install.ps1
@@ -69,7 +69,7 @@ $realPath = if ($scriptItem.LinkType) {
 . "$realPath\functions\Get-WingetCmd.ps1"
 . "$realPath\functions\Write-ToLog.ps1"
 . "$realPath\functions\Confirm-Installation.ps1"
-
+. "$realPath\functions\Compare-SemVer.ps1"
 
 #Check if App exists in Winget Repository
 function Confirm-Exist ($AppID) {

--- a/Sources/Winget-AutoUpdate/Winget-Install.ps1
+++ b/Sources/Winget-AutoUpdate/Winget-Install.ps1
@@ -225,7 +225,7 @@ function Uninstall-App ($AppID, $AppArgs) {
 
         #Uninstall App
         Write-ToLog "-> Uninstalling $AppID..." "Yellow"
-        $WingetArgs = "uninstall --id $AppID -e --accept-source-agreements -h" -split " "
+        $WingetArgs = "uninstall --id $AppID -e --accept-source-agreements -h $AppArgs" -split " "
         Write-ToLog "-> Running: `"$Winget`" $WingetArgs"
         & "$Winget" $WingetArgs | Where-Object { $_ -notlike "   *" } | Tee-Object -file $LogFile -Append
 

--- a/Sources/Winget-AutoUpdate/functions/Test-Mods.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Test-Mods.ps1
@@ -22,10 +22,10 @@ function Test-Mods ($app) {
             $ModsPreInstall = "$Mods\$app-preinstall.ps1"
         } 
         if (Test-Path "$Mods\$app-override.txt") {
-            $ModsOverride = Get-Content "$Mods\$app-override.txt" -Raw
+            $ModsOverride = (Get-Content "$Mods\$app-override.txt" -Raw).Trim()
         }
         if (Test-Path "$Mods\$app-custom.txt") {
-            $ModsCustom = Get-Content "$Mods\$app-custom.txt" -Raw
+            $ModsCustom = (Get-Content "$Mods\$app-custom.txt" -Raw).Trim()
         }
         if (Test-Path "$Mods\$app-install.ps1") {
             $ModsInstall = "$Mods\$app-install.ps1"


### PR DESCRIPTION
# Proposed Changes
- Making sure the imported $app-override.txt/$app-custom.txt are TRIM:ed before import to the variable
- Winget-Install needs Compare-SemVer too
- $AppArgs in WinGet -Uninstall too

Branch name error (should be `develop/trimraw`)

## Related Issues
#881 #785 