### PR TITLE
New feat: Retry logic & exit with winget Exitcode

### DIFF
--- a/Sources/Winget-AutoUpdate/functions/Write-ToLog.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Write-ToLog.ps1
@@ -33,6 +33,9 @@ function Write-ToLog {
     }
 
     #Echo log
+    if ([String]::IsNullOrEmpty($LogColor)) {
+        $LogColor = "White"
+    }
     $Log | Write-host -ForegroundColor $LogColor
 
     #Write log to file


### PR DESCRIPTION
# Proposed Changes
Sometimes a installation in our company environment fails due to "another installation is already in progress". 
This PR adds a simple retry logic, where an installation will be tried three times per default. This can be disabled with the param `-DisableRetry`.
Also Winget-Install now exits the script not always with 0 (success), instead the winget installation return code will be used to exit this script. This helps with handling Error Codes through SCCM & Intune.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
