### PR TITLE
Random Delay for Main Scheduled Task

### DIFF
--- a/.github/workflows/GitFlow_Make-Release-and-Sync-to-Dev.yml
+++ b/.github/workflows/GitFlow_Make-Release-and-Sync-to-Dev.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           lfs: "true"
           fetch-depth: 0
-          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       # Step 2: Extract version from branch name and calculate build number
       - name: Get final Release Version

--- a/Sources/Policies/ADMX/WAU.admx
+++ b/Sources/Policies/ADMX/WAU.admx
@@ -10,6 +10,7 @@
     <definitions>
       <definition name="SUPPORTED_WAU_1_16_0" displayName="$(string.SUPPORTED_WAU_1_16_0)" />
       <definition name="SUPPORTED_WAU_1_16_5" displayName="$(string.SUPPORTED_WAU_1_16_5)" />
+      <definition name="SUPPORTED_WAU_2_5_2" displayName="$(string.SUPPORTED_WAU_2_5_2)" />
       <definition name="SUPPORTED_WAU_EXPERIMENTAL"
         displayName="$(string.SUPPORTED_WAU_EXPERIMENTAL)" />
     </definitions>
@@ -418,6 +419,17 @@
       <supportedOn ref="WAU:SUPPORTED_WAU_EXPERIMENTAL" />
       <elements>
         <text id="WingetSourceCustom" valueName="WAU_WingetSourceCustom" />
+      </elements>
+    </policy>
+    <policy name="UpdatesTime_Delay" class="Machine"
+      displayName="$(string.UpdatesTimeDelay_Name)"
+      explainText="$(string.UpdatesTimeDelay_Explain)"
+      key="Software\Policies\Romanitho\Winget-AutoUpdate"
+      presentation="$(presentation.UpdatesTimeDelayTime)">
+      <parentCategory ref="WAU" />
+      <supportedOn ref="WAU:SUPPORTED_WAU_2_5_2" />
+      <elements>
+        <text id="UpdatesTimeDelayTime" valueName="WAU_UpdatesTimeDelay" />
       </elements>
     </policy>
   </policies>

--- a/Sources/Policies/ADMX/WAU.admx
+++ b/Sources/Policies/ADMX/WAU.admx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="4.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="5.0"
   schemaVersion="1.0" xmlns="http://www.microsoft.com/GroupPolicy/PolicyDefinitions">
   <policyNamespaces>
     <target prefix="WAU" namespace="Romanitho.Policies.WAU" />

--- a/Sources/Policies/ADMX/en-US/WAU.adml
+++ b/Sources/Policies/ADMX/en-US/WAU.adml
@@ -10,6 +10,7 @@
       <string id="WAUEX">Experimental</string>
       <string id="SUPPORTED_WAU_1_16_0">Winget-AutoUpdate version 1.16.0 or later</string>
       <string id="SUPPORTED_WAU_1_16_5">Winget-AutoUpdate version 1.16.5 or later</string>
+      <string id="SUPPORTED_WAU_2_5_2">Winget-AutoUpdate version 2.5.2 or later</string>
       <string id="SUPPORTED_WAU_EXPERIMENTAL">Winget-AutoUpdate Experimental, subject to change, do
         not use on PROD</string>
       <string id="ActivateGPOManagement_Name">Activate WAU GPO Management</string>
@@ -185,6 +186,15 @@
 
         If this policy is disabled or not configured, the default is always the
         built-in winget.</string>
+      <string id="UpdatesTimeDelay_Name">Random delay for scheduled task triggers</string>
+      <string id="UpdatesTimeDelay_Explain">This policy setting specifies the delay for the scheduled task.
+      A scheduled task random delay adds a random amount of wait time (up to the specified maximum) before the task starts. 
+      This helps prevent many devices from running the task at the exact same time. This is not applicable to "on logon" triggers.
+
+      If this policy is enabled, the scheduled task will have a random delay set
+      based on the time inputted. 
+
+      If this policy is disabled or not configured, the default no delay.</string>
     </stringTable>
     <presentationTable>
       <presentation id="BlackList">
@@ -230,6 +240,11 @@
       <presentation id="WingetSourceCustom">
         <textBox refId="WingetSourceCustom">
           <label>Name of custom winget source:</label>
+        </textBox>
+      </presentation>
+      <presentation id="UpdatesTimeDelayTime">
+        <textBox refId="UpdatesTimeDelayTime">
+          <label>Random delay HH:mm</label>
         </textBox>
       </presentation>
     </presentationTable>

--- a/Sources/Winget-AutoUpdate/WAU-Policies.ps1
+++ b/Sources/Winget-AutoUpdate/WAU-Policies.ps1
@@ -87,14 +87,8 @@ if ($WAUConfig.WAU_RunGPOManagement -eq 1) {
         $configChanged = $true
     }
 
-    #Check if delay is set
-    if ($WAUConfig.WAU_UpdatesTimeDelay) {
-        $randomDelay = [TimeSpan]::ParseExact($WAUConfig.WAU_UpdatesTimeDelay, "hh\:mm", $null)
-    } else {   
-        $randomDelay = [TimeSpan]::ParseExact("00:00", "hh\:mm", $null) #setting to 00:00 disables the random delay
-    }
-
     #Check if delay has changed
+    $randomDelay = [TimeSpan]::ParseExact($WAUConfig.WAU_UpdatesTimeDelay, "hh\:mm", $null)
     $timeTrigger = $currentTriggers | Where-Object { $_.CimClass.CimClassName -ne "MSFT_TaskLogonTrigger" } | Select-Object -First 1
     if ($timeTrigger.RandomDelay -match '^PT(?:(\d+)H)?(?:(\d+)M)?$') {
         $hours = if ($matches[1]) { [int]$matches[1] } else { 0 }

--- a/Sources/Wix/build.wxs
+++ b/Sources/Wix/build.wxs
@@ -83,6 +83,10 @@
         <Property Id="UPDATESATTIME_VALUE" Value="06:00:00">
             <RegistrySearch Id="SearchUpdatesAtTime" Type="raw" Root="HKLM" Key="SOFTWARE\[Manufacturer]\[ProductName]" Name="WAU_UpdatesAtTime"  />
         </Property>
+        <Property Id="UPDATESATTIMEDELAY" Secure="yes" />
+        <Property Id="UPDATESATTIMEDELAY_VALUE" Value="00:00">
+            <RegistrySearch Id="DelayUpdatesAtTime" Type="raw" Root="HKLM" Key="SOFTWARE\[Manufacturer]\[ProductName]" Name="WAU_UpdatesTimeDelay"  />
+        </Property>
         <Property Id="BYPASSLISTFORUSERS" Secure="yes" />
         <Property Id="BYPASSLISTFORUSERS_VALUE" Value="#0">
             <RegistrySearch Id="SearchBypassListForUsers" Type="raw" Root="HKLM" Key="SOFTWARE\[Manufacturer]\[ProductName]" Name="WAU_BypassListForUsers"  />
@@ -257,6 +261,7 @@
         <SetProperty Id="AZUREBLOBURL_VALUE" After="AppSearch" Value="[AZUREBLOBURL]" Condition="AZUREBLOBURL" />
         <SetProperty Id="DONOTRUNONMETERED_VALUE" After="AppSearch" Value="#[DONOTRUNONMETERED]" Condition="DONOTRUNONMETERED" />
         <SetProperty Id="UPDATESATTIME_VALUE" After="AppSearch" Value="[UPDATESATTIME]" Condition="UPDATESATTIME" />
+        <SetProperty Id="UPDATESATTIMEDELAY_VALUE" After="AppSearch" Value="00:00" Condition="UPDATESATTIMEDELAY" />
         <SetProperty Id="BYPASSLISTFORUSERS_VALUE" After="AppSearch" Value="#[BYPASSLISTFORUSERS]" Condition="BYPASSLISTFORUSERS" />
         <SetProperty Id="MAXLOGFILES_VALUE" After="AppSearch" Value="#[MAXLOGFILES]" Condition="MAXLOGFILES" />
         <SetProperty Id="MAXLOGSIZE_VALUE" After="AppSearch" Value="#[MAXLOGSIZE]" Condition="MAXLOGSIZE" />
@@ -329,6 +334,9 @@
 					</RegistryKey>
 					<RegistryKey Key="SOFTWARE\[Manufacturer]\[ProductName]" Root="HKLM">
 						<RegistryValue Name="WAU_UpdatesAtTime" Type="string" Value="[UPDATESATTIME_VALUE]" />
+					</RegistryKey>
+					<RegistryKey Key="SOFTWARE\[Manufacturer]\[ProductName]" Root="HKLM">
+						<RegistryValue Name="WAU_UpdatesTimeDelay" Type="string" Value="[UPDATESATTIMEDELAY_VALUE]" />
 					</RegistryKey>
 					<RegistryKey Key="SOFTWARE\[Manufacturer]\[ProductName]" Root="HKLM">
 						<RegistryValue Name="WAU_BypassListForUsers" Type="string" Value="[BYPASSLISTFORUSERS_VALUE]" />


### PR DESCRIPTION
Added in scheduled task random delay for scheduled task time triggers. Added to admx/adml.
This helps when running on multiple devices, adding in a random delay to stop devices all running and downloading at the same time.