### PR TITLE
Add parsec to exclusion list (remote app like teamviewer)

### DIFF
--- a/Sources/Winget-AutoUpdate/config/default_excluded_apps.txt
+++ b/Sources/Winget-AutoUpdate/config/default_excluded_apps.txt
@@ -7,5 +7,6 @@ Microsoft.RemoteDesktopClient
 Microsoft.Teams*
 Mozilla.Firefox*
 Opera.Opera*
+Parsec.Parsec
 TeamViewer.TeamViewer*
 Romanitho.Winget-AutoUpdate


### PR DESCRIPTION
# Proposed Changes

Add parsec to exclusion list (remote app like teamviewer). Connection should obviously not break, just to update the app

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
