### PR TITLE
Winget-Install with -override.txt and -custom.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Instead of including the override parameters in the install string you can use a
 * A standard single installation: **-AppIDs Notepad++.Notepad++**
 * Multiple installations: **-AppIDs "7zip.7zip, Notepad++.Notepad++"**
 
-As a detection script use **config\winget-detect.ps1** (change app to detect [**Application ID**]) in **Intune**/**SCCM** ([winget-detect.ps1](Sources/Winget-AutoUpdate/config/winget-detect.ps1))
+As a detection script use **config\winget-detect.ps1** (change app to detect [**Application ID**]) in **Intune**/**SCCM** ([winget-detect.ps1](Sources/Winget-AutoUpdate/Tools/Detection/winget-detect.ps1))
 
 A nice feature is if you're already using the deprecated standalone script **winget-install.ps1** from the [old repo](https://github.com/Romanitho/Winget-Install) and have placed it somwhere locally on all clients you can make a **SymLink** in its place and keep using the old path (avoiding a lot of work) in your deployed applications (**Winget-Install.ps1** takes care of the SymLink logic).
 

--- a/Sources/Tools/Detection/winget-detect.ps1
+++ b/Sources/Tools/Detection/winget-detect.ps1
@@ -1,3 +1,12 @@
+<#
+.SYNOPSIS
+Helper script to use as detection method with Intune or SCCM.
+
+.DESCRIPTION
+This script uses `winget export` to detect if a specific application is installed.
+Intended for use as a detection rule script in Intune or SCCM deployments.
+#>
+
 #Change app to detect [Application ID]
 $AppToDetect = "Notepad++.Notepad++"
 

--- a/Sources/Winget-AutoUpdate/Winget-Install.ps1
+++ b/Sources/Winget-AutoUpdate/Winget-Install.ps1
@@ -160,7 +160,7 @@ function Install-App ($AppID, $AppArgs) {
         }
 
         Write-ToLog "-> Running: `"$Winget`" $WingetArgs"
-	& "$Winget" $WingetArgs | Where-Object { $_ -notlike "   *" } | Tee-Object -file $LogFile -Append
+        & "$Winget" $WingetArgs | Where-Object { $_ -notlike "   *" } | Tee-Object -file $LogFile -Append
 
         if ($ModsInstall) {
             Write-ToLog "-> Modifications for $AppID during install are being applied..." "DarkYellow"
@@ -212,7 +212,7 @@ function Uninstall-App ($AppID, $AppArgs) {
         Write-ToLog "-> Uninstalling $AppID..." "DarkYellow"
         $WingetArgs = "uninstall --id $AppID -e --accept-source-agreements -h $AppArgs" -split " "
         Write-ToLog "-> Running: `"$Winget`" $WingetArgs"
-	& "$Winget" $WingetArgs | Where-Object { $_ -notlike "   *" } | Tee-Object -file $LogFile -Append
+        & "$Winget" $WingetArgs | Where-Object { $_ -notlike "   *" } | Tee-Object -file $LogFile -Append
 
         if ($ModsUninstall) {
             Write-ToLog "-> Modifications for $AppID during uninstall are being applied..." "DarkYellow"
@@ -294,6 +294,7 @@ $Script:IsElevated = $CurrentPrincipal.IsInRole([Security.Principal.WindowsBuilt
 #Get WAU Installed location
 $WAURegKey = "HKLM:\SOFTWARE\Romanitho\Winget-AutoUpdate\"
 $Script:WAUInstallLocation = Get-ItemProperty $WAURegKey -ErrorAction SilentlyContinue | Select-Object -ExpandProperty InstallLocation
+
 # Use the Working Dir (even if it is from a symlink)
 $Mods = "$realPath\mods"
 

--- a/Sources/Winget-AutoUpdate/config/winget-detect.ps1
+++ b/Sources/Winget-AutoUpdate/config/winget-detect.ps1
@@ -1,0 +1,53 @@
+#Change app to detect [Application ID]
+$AppToDetect = "Notepad++.Notepad++"
+
+
+<# FUNCTIONS #>
+
+Function Get-WingetCmd {
+
+    $WingetCmd = $null
+
+    #Get WinGet Path
+    try {
+        #Get Admin Context Winget Location
+        $WingetInfo = (Get-Item "$env:ProgramFiles\WindowsApps\Microsoft.DesktopAppInstaller_*_8wekyb3d8bbwe\winget.exe").VersionInfo | Sort-Object -Property FileVersionRaw
+        #If multiple versions, pick most recent one
+        $WingetCmd = $WingetInfo[-1].FileName
+    }
+    catch {
+        #Get User context Winget Location
+        if (Test-Path "$env:LocalAppData\Microsoft\WindowsApps\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\winget.exe") {
+            $WingetCmd = "$env:LocalAppData\Microsoft\WindowsApps\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\winget.exe"
+        }
+    }
+
+    return $WingetCmd
+}
+
+<# MAIN #>
+
+#Get WinGet Location Function
+$winget = Get-WingetCmd
+
+#Set json export file
+$JsonFile = "$env:TEMP\InstalledApps.json"
+
+#Get installed apps and version in json file
+& $Winget export -o $JsonFile --accept-source-agreements | Out-Null
+
+#Get json content
+$Json = Get-Content $JsonFile -Raw | ConvertFrom-Json
+
+#Get apps and version in hashtable
+$Packages = $Json.Sources.Packages
+
+#Remove json file
+Remove-Item $JsonFile -Force
+
+# Search for specific app and version
+$Apps = $Packages | Where-Object { $_.PackageIdentifier -eq $AppToDetect }
+
+if ($Apps) {
+    return "Installed!"
+}

--- a/Sources/Winget-AutoUpdate/mods/README.md
+++ b/Sources/Winget-AutoUpdate/mods/README.md
@@ -24,13 +24,15 @@ The **-install** mod will be used for upgrades too if **-upgrade** doesn't exist
 
 `AppID-install.ps1` is recommended because it's used in **both** scenarios.
 
+If **AppID**`-preinstall.ps1`/`-preuninstall.ps1` returns `$false`, the install/update/uninstall for that **AppID** is skipped (checking if an App is running, etc...).
+
 A script **Template** for an all-purpose mod (`_WAU-notinstalled-template.ps1`) is included in which actions can be taken if an upgrade/install fails for any **AppID** (any individual `AppID-notinstalled.ps1` overrides this global one)
 Name it `_WAU-notinstalled.ps1` for activation
 
 ### Winget native parameters:
 Another finess is the **AppID** followed by the `-override` or `-custom` suffix as a **text file** (**.txt**).
 > Example:  
->  **Canneverbe.CDBurnerXP-override.txt** with the content `ADDLOCAL=All REMOVE=Desktop_Shortcut /qn`
+>  **Adobe.Acrobat.Reader.64-bit-override.txt** with the content `"-sfx_nu /sAll /rs /msi EULA_ACCEPT=YES DISABLEDESKTOPSHORTCUT=1"`
 
 > Example:  
 >  **ShareX.ShareX-custom.txt** with the content `/MERGETASKS=!CreateDesktopIcon`

--- a/Sources/Winget-AutoUpdate/mods/_AppID-template.ps1
+++ b/Sources/Winget-AutoUpdate/mods/_AppID-template.ps1
@@ -20,6 +20,10 @@ $RunSystem = ""
 $RunSwitch = ""
 $RunWait = $True
 
+# Beginning of Process Name to check for if running - optional wildcard (*) after, without .exe, multiple: "proc1*","proc2"
+# If found, it will return $False (to $preInstall-/UninstallResult), stop this script and request for the main script to skip the app.
+$SkipApp = @("")
+
 # Beginning of Process Name to Stop - optional wildcard (*) after, without .exe, multiple: "proc1*","proc2"
 $Proc = @("")
 
@@ -99,6 +103,10 @@ $User = $True
 <# MAIN #>
 if ($RunSystem) {
     Invoke-ModsApp $RunSystem $RunSwitch $RunWait ""
+}
+if ($SkipApp) {
+    $result = Skip-ModsProc $SkipApp
+    if ($result -eq $true) { return $false }
 }
 if ($Proc) {
     Stop-ModsProc $Proc

--- a/Sources/Winget-AutoUpdate/mods/_Mods-Functions.ps1
+++ b/Sources/Winget-AutoUpdate/mods/_Mods-Functions.ps1
@@ -18,6 +18,15 @@ function Invoke-ModsApp ($Run, $RunSwitch, $RunWait, $User) {
     Return
 }
 
+function Skip-ModsProc ($SkipApp) {
+    foreach ($process in $SkipApp) {
+        $running = Get-Process -Name $process -ErrorAction SilentlyContinue
+        if ($running) {
+            Return $true
+        }
+    }
+    Return
+}
 
 function Stop-ModsProc ($Proc) {
     foreach ($process in $Proc) {
@@ -25,6 +34,7 @@ function Stop-ModsProc ($Proc) {
     }
     Return
 }
+
 function Stop-ModsSvc ($Svc) {
     foreach ($service in $Svc) {
         Stop-Service -Name $service -Force -ErrorAction SilentlyContinue | Out-Null


### PR DESCRIPTION
# Proposed Changes

> Enhance Winget-Install.ps1, deployment instructions and mod functionality in README and scripts

- Updated README.md to include deployment examples for SCCM and Intune.
- Improved Winget-Install.ps1 to handle mod overrides and custom parameters.
- Enhanced Update-App.ps1 to support pre-install checks.
- Added functionality to skip apps based on running processes in mod templates.
- Introduced new functions for process management in _Mods-Functions.ps1.
- Implemented winget-detect.ps1 for detecting installed applications.



## Related Issues

> Fixes #810 
