### PR TITLE
Add "Errors" option to -NotificationLevel

### DIFF
--- a/Sources/Policies/ADMX/WAU.admx
+++ b/Sources/Policies/ADMX/WAU.admx
@@ -164,6 +164,11 @@
               <string>SuccessOnly</string>
             </value>
           </item>
+          <item displayName="$(string.NotificationLevel_ErrorsOnly)">
+            <value>
+              <string>ErrorsOnly</string>
+            </value>
+          </item>
           <item displayName="$(string.NotificationLevel_None)">
             <value>
               <string>None</string>

--- a/Sources/Policies/ADMX/en-US/WAU.adml
+++ b/Sources/Policies/ADMX/en-US/WAU.adml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="4.8" schemaVersion="1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="5.0" schemaVersion="1.0"
   xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <displayName>WinGet-AutoUpdate</displayName>
   <description>WinGet-AutoUpdate GPO Management</description>
@@ -58,7 +58,7 @@
         (URL/UNC/GPO/Local)</string>
       <string id="ListPath_Explain">If this policy is enabled, you can set a
         (URL/UNC/GPO/Local) Path to external lists other than the default.
-        If "Application GPO Blacklist/Whitelist" is set in this GPO the Path can be:
+        If "Application GPO Blacklist/Whitelist" is set in this GPO the Path MUST be:
         GPO
 
         If this policy is disabled or not configured, the default ListPath is used
@@ -84,12 +84,14 @@
         configure the Notification Level:
         1. Full (Default)
         2. SuccessOnly
-        3. None
+        3. ErrorsOnly
+        4. None
 
         If this policy is not configured or disabled, Notification Level: (1. Full).</string>
       <string id="NotificationLevel_Full">1. Full (Default)</string>
       <string id="NotificationLevel_SuccessOnly">2. SuccessOnly</string>
-      <string id="NotificationLevel_None">3. None</string>
+      <string id="NotificationLevel_ErrorsOnly">3. ErrorsOnly</string>
+      <string id="NotificationLevel_None">4. None</string>
       <string id="UpdatesInterval_Name">Updates Interval</string>
       <string id="UpdatesInterval_Explain">If this policy is enabled, you can configure
         the Updates Interval:

--- a/Sources/Winget-AutoUpdate/functions/Start-NotifTask.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Start-NotifTask.ps1
@@ -15,7 +15,7 @@ function Start-NotifTask {
         [Switch]$UserRun = $false
     )
 
-    if (($WAUConfig.WAU_NotificationLevel -eq "Full") -or ($WAUConfig.WAU_NotificationLevel -eq "SuccessOnly" -and $MessageType -eq "Success") -or ($UserRun)) {
+    if (($WAUConfig.WAU_NotificationLevel -eq "Full") -or ($WAUConfig.WAU_NotificationLevel -eq "SuccessOnly" -and $MessageType -eq "Success") -or ($WAUConfig.WAU_NotificationLevel -eq "ErrorsOnly" -and $MessageType -eq "Error") -or ($UserRun)) {
 
         # XML Toast template creation
         [xml]$ToastTemplate = New-Object system.Xml.XmlDocument

--- a/Sources/Wix/build.wxs
+++ b/Sources/Wix/build.wxs
@@ -200,6 +200,7 @@
                     <ComboBox Property="NOTIFICATIONLEVEL_VALUE">
                         <ListItem Value="Full" Text="Full" />
                         <ListItem Value="SuccessOnly" Text="Success only" />
+                        <ListItem Value="ErrorsOnly" Text="Errors only" />
                         <ListItem Value="None" Text="None" />
                     </ComboBox>
                 </Control>


### PR DESCRIPTION
# Proposed Changes

> Adds the option to set -NotificationLevel to 'ErrorsOnly' in install/reg/policy

## Related Issues

> Closes #596 