### PR TITLE
Default GPO setting is a GPO list is configured

### DIFF
--- a/Sources/Policies/ADMX/WAU.admx
+++ b/Sources/Policies/ADMX/WAU.admx
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="5.1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="5.2"
   schemaVersion="1.0" xmlns="http://www.microsoft.com/GroupPolicy/PolicyDefinitions">
   <policyNamespaces>
     <target prefix="WAU" namespace="Romanitho.Policies.WAU" />
   </policyNamespaces>
-  <resources minRequiredRevision="5.1" fallbackCulture="en-us" />
+  <resources minRequiredRevision="5.2" fallbackCulture="en-us" />
   <supportedOn>
     <definitions>
       <definition name="SUPPORTED_WAU_1_16_0" displayName="$(string.SUPPORTED_WAU_1_16_0)" />

--- a/Sources/Policies/ADMX/en-US/WAU.adml
+++ b/Sources/Policies/ADMX/en-US/WAU.adml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="5.1" schemaVersion="1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="5.2" schemaVersion="1.0"
   xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <displayName>WinGet-AutoUpdate</displayName>
   <description>WinGet-AutoUpdate GPO Management</description>

--- a/Sources/Policies/ADMX/en-US/WAU.adml
+++ b/Sources/Policies/ADMX/en-US/WAU.adml
@@ -47,9 +47,9 @@ If this policy is disabled or not configured, GPO Whitelist is not used.</string
       <string id="UseWhiteList_Explain">This policy setting specifies whether to use a Whitelist or not.
 
 If this policy is disabled or not configured, the default is No.</string>
-      <string id="ListPath_Name">Get Black/White List from external Path (URL/UNC/GPO/Local)</string>
-      <string id="ListPath_Explain">If this policy is enabled, you can set a (URL/UNC/GPO/Local) Path to external lists other than the default.
-If "Application GPO Blacklist/Whitelist" is set in this GPO the Path MUST be: GPO
+      <string id="ListPath_Name">Get Black/White List from external Path (URL/UNC/Local)</string>
+      <string id="ListPath_Explain">If this policy is enabled, you can set a (URL/UNC/Local) Path to external lists other than the default.
+If "Application GPO Blacklist/Whitelist" is set, this policy setting is ignored.
 
 If this policy is disabled or not configured, the default ListPath is used (WAU InstallLocation).</string>
       <string id="ModsPath_Name">Get Mods from external Path (URL/UNC/Local/AzureBlob)</string>
@@ -163,7 +163,7 @@ If this policy is disabled or not configured, the default no delay.</string>
       </presentation>
       <presentation id="ListPath">
         <textBox refId="ListPath">
-          <label>(URL/UNC/GPO/Local) Path:</label>
+          <label>(URL/UNC/Local) Path:</label>
         </textBox>
       </presentation>
       <presentation id="ModsPath">

--- a/Sources/Winget-AutoUpdate/Winget-Upgrade.ps1
+++ b/Sources/Winget-AutoUpdate/Winget-Upgrade.ps1
@@ -302,10 +302,6 @@ if (Test-Network) {
 
         }
 
-        if ($($WAUConfig.WAU_ListPath) -eq "GPO") {
-            $Script:GPOList = $True
-        }
-
         #Get White or Black list
         if ($WAUConfig.WAU_UseWhiteList -eq 1) {
             Write-ToLog "WAU uses White List config"
@@ -315,26 +311,6 @@ if (Test-Network) {
         else {
             Write-ToLog "WAU uses Black List config"
             $toSkip = Get-ExcludedApps
-        }
-
-        #Fix and count the array if GPO List as ERROR handling!
-        if ($GPOList) {
-            if ($UseWhiteList) {
-                if (-not $toUpdate) {
-                    Write-ToLog "Critical: Whitelist doesn't exist in GPO, exiting..." "Red"
-                    New-Item "$WorkingDir\logs\error.txt" -Value "Whitelist doesn't exist in GPO" -Force
-                    Exit 1
-                }
-                foreach ($app in $toUpdate) { Write-ToLog "Include app ${app}" }
-            }
-            else {
-                if (-not $toSkip) {
-                    Write-ToLog "Critical: Blacklist doesn't exist in GPO, exiting..." "Red"
-                    New-Item "$WorkingDir\logs\error.txt" -Value "Blacklist doesn't exist in GPO" -Force
-                    Exit 1
-                }
-                foreach ($app in $toSkip) { Write-ToLog "Exclude app ${app}" }
-            }
         }
 
         #Get outdated Winget packages

--- a/Sources/Winget-AutoUpdate/functions/Get-ExcludedApps.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Get-ExcludedApps.ps1
@@ -15,29 +15,6 @@ function Get-ExcludedApps {
             Write-ToLog "Exclude app $app"
         }
     }
-    #blacklist pulled from URI
-    elseif ($URIList) {
-
-        $RegPath = "$WAU_GPORoot";
-        $RegValueName = 'WAU_URIList';
-
-        if (Test-Path -Path $RegPath) {
-            $RegKey = Get-Item -Path $RegPath;
-            $WAUURI = $RegKey.GetValue($RegValueName);
-            Write-ToLog "-> Excluded apps from URI is activated"
-            if ($null -ne $WAUURI) {
-                $resp = Invoke-WebRequest -Uri $WAUURI -UseDefaultCredentials;
-                if ($resp.BaseResponse.StatusCode -eq [System.Net.HttpStatusCode]::OK) {
-                    $resp.Content.Split([System.Environment]::NewLine, [System.StringSplitOptions]::RemoveEmptyEntries) |
-                    ForEach-Object {
-                        $AppIds += $_
-                    }
-                    Write-ToLog "-> Successsfully loaded excluded apps list."
-                }
-            }
-        }
-
-    }
     #blacklist pulled from local file
     elseif (Test-Path "$WorkingDir\excluded_apps.txt") {
 

--- a/Sources/Winget-AutoUpdate/functions/Get-ExcludedApps.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Get-ExcludedApps.ps1
@@ -4,18 +4,16 @@ function Get-ExcludedApps {
 
     $AppIDs = @()
 
-    #blacklist in registry
-    if ($GPOList) {
-
+    #blacklist in Policies registry
+    if (Test-Path "HKLM:\SOFTWARE\Policies\Romanitho\Winget-AutoUpdate\BlackList") {
         Write-ToLog "-> Excluded apps from GPO is activated"
-        if (Test-Path "HKLM:\SOFTWARE\Policies\Romanitho\Winget-AutoUpdate\BlackList") {
-            $ValueNames = (Get-Item -Path "HKLM:\SOFTWARE\Policies\Romanitho\Winget-AutoUpdate\BlackList").Property
-            foreach ($ValueName in $ValueNames) {
-                $AppIDs += (Get-ItemPropertyValue -Path "HKLM:\SOFTWARE\Policies\Romanitho\Winget-AutoUpdate\BlackList" -Name $ValueName).Trim()
-            }
-            Write-ToLog "-> Successsfully loaded excluded apps list."
+        $ValueNames = (Get-Item -Path "HKLM:\SOFTWARE\Policies\Romanitho\Winget-AutoUpdate\BlackList").Property
+        foreach ($ValueName in $ValueNames) {
+            $AppIDs += (Get-ItemPropertyValue -Path "HKLM:\SOFTWARE\Policies\Romanitho\Winget-AutoUpdate\BlackList" -Name $ValueName).Trim()
         }
-
+        foreach ($app in $AppIDs) {
+            Write-ToLog "Exclude app $app"
+        }
     }
     #blacklist pulled from URI
     elseif ($URIList) {

--- a/Sources/Winget-AutoUpdate/functions/Get-IncludedApps.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Get-IncludedApps.ps1
@@ -1,20 +1,19 @@
 #Function to get the allow List apps
 
 function Get-IncludedApps {
+
     $AppIDs = @()
 
-    #whitelist in registry
-    if ($GPOList) {
-
+    #whitelist in Policies registry
+    if (Test-Path "HKLM:\SOFTWARE\Policies\Romanitho\Winget-AutoUpdate\WhiteList") {
         Write-ToLog "-> Included apps from GPO is activated"
-        if (Test-Path "HKLM:\SOFTWARE\Policies\Romanitho\Winget-AutoUpdate\WhiteList") {
-            $ValueNames = (Get-Item -Path "HKLM:\SOFTWARE\Policies\Romanitho\Winget-AutoUpdate\WhiteList").Property
-            foreach ($ValueName in $ValueNames) {
-                $AppIDs += (Get-ItemPropertyValue -Path "HKLM:\SOFTWARE\Policies\Romanitho\Winget-AutoUpdate\WhiteList" -Name $ValueName).Trim()
-            }
-            Write-ToLog "-> Successsfully loaded included apps list."
+        $ValueNames = (Get-Item -Path "HKLM:\SOFTWARE\Policies\Romanitho\Winget-AutoUpdate\WhiteList").Property
+        foreach ($ValueName in $ValueNames) {
+            $AppIDs += (Get-ItemPropertyValue -Path "HKLM:\SOFTWARE\Policies\Romanitho\Winget-AutoUpdate\WhiteList" -Name $ValueName).Trim()
         }
-
+        foreach ($app in $AppIDs) {
+            Write-ToLog "Include app $app"
+        }
     }
     #whitelist pulled from URI
     elseif ($URIList) {

--- a/Sources/Winget-AutoUpdate/functions/Get-IncludedApps.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Get-IncludedApps.ps1
@@ -15,29 +15,6 @@ function Get-IncludedApps {
             Write-ToLog "Include app $app"
         }
     }
-    #whitelist pulled from URI
-    elseif ($URIList) {
-
-        $RegPath = "$WAU_GPORoot";
-        $RegValueName = 'WAU_URIList';
-
-        if (Test-Path -Path $RegPath) {
-            $RegKey = Get-Item -Path $RegPath;
-            $WAUURI = $RegKey.GetValue($RegValueName);
-            Write-ToLog "-> Included apps from URI is activated"
-            if ($null -ne $WAUURI) {
-                $resp = Invoke-WebRequest -Uri $WAUURI -UseDefaultCredentials;
-                if ($resp.BaseResponse.StatusCode -eq [System.Net.HttpStatusCode]::OK) {
-                    $resp.Content.Split([System.Environment]::NewLine, [System.StringSplitOptions]::RemoveEmptyEntries) |
-                    ForEach-Object {
-                        $AppIds += $_
-                    }
-                    Write-ToLog "-> Successsfully loaded included apps list."
-                }
-            }
-        }
-
-    }
     #whitelist pulled from local file
     elseif (Test-Path "$WorkingDir\included_apps.txt") {
 


### PR DESCRIPTION
# Proposed Changes

If `Application GPO Blacklist` or `Application GPO Whitelist` is configured, it is not necessary to set `Get Black/White List from external Path (URL/UNC/GPO/Local)` to **GPO** anymore.
To configure an external path, leave  `Application GPO Blacklist` or `Application GPO Whitelist` to **Not Configured**

This should be more intuitive.

## Related Issues

> For example: #1007 
