### PR TITLE
Refactor Add-ScopeMachine function to improve settings file handling and ensure proper structure for installBehavior and preferences

### DIFF
--- a/Sources/Winget-AutoUpdate/functions/Add-ScopeMachine.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Add-ScopeMachine.ps1
@@ -3,7 +3,7 @@ function Add-ScopeMachine {
 
     #Get Settings path for system or current user
     if ([System.Security.Principal.WindowsIdentity]::GetCurrent().IsSystem) {
-        $SettingsPath = "$Env:windir\System32\config\systemprofile\AppData\Local\Microsoft\WinGet\Settings\defaultState\settings.json"
+        $SettingsPath = "$env:windir\System32\config\systemprofile\AppData\Local\Microsoft\WinGet\Settings\defaultState\settings.json"
     }
     else {
         $SettingsPath = "$env:LOCALAPPDATA\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\LocalState\settings.json"
@@ -13,19 +13,38 @@ function Add-ScopeMachine {
 
     #Check if setting file exist, if not create it
     if (Test-Path $SettingsPath) {
-        $ConfigFile = Get-Content -Path $SettingsPath | Where-Object { $_ -notmatch '//' } | ConvertFrom-Json
+        try {
+            # Read the entire file as raw content to preserve structure
+            $jsonContent = Get-Content -Path $SettingsPath -Raw -Encoding UTF8
+            $ConfigFile = $jsonContent | ConvertFrom-Json
+        }
+        catch {
+            # If JSON parsing fails, create empty config
+            Write-Warning "Failed to parse existing settings.json: $($_.Exception.Message)"
+            $ConfigFile = New-Object PSObject
+        }
     }
     else {
         New-Item -Path $SettingsPath -Force | Out-Null
+        $ConfigFile = New-Object PSObject
     }
 
-    if ($ConfigFile.installBehavior.preferences) {
-        Add-Member -InputObject $ConfigFile.installBehavior.preferences -MemberType NoteProperty -Name "scope" -Value "Machine" -Force
+    # Ensure installBehavior exists
+    if (-not $ConfigFile.installBehavior) {
+        Add-Member -InputObject $ConfigFile -MemberType NoteProperty -Name "installBehavior" -Value (New-Object PSObject) -Force
+    }
+
+    # Ensure preferences exists within installBehavior
+    if (-not $ConfigFile.installBehavior.preferences) {
+        Add-Member -InputObject $ConfigFile.installBehavior -MemberType NoteProperty -Name "preferences" -Value (New-Object PSObject) -Force
+    }
+
+    # Add or update scope preference
+    if ($ConfigFile.installBehavior.preferences.scope) {
+        $ConfigFile.installBehavior.preferences.scope = "Machine"
     }
     else {
-        $Scope = New-Object PSObject -Property $(@{scope = "Machine" })
-        $Preference = New-Object PSObject -Property $(@{preferences = $Scope })
-        Add-Member -InputObject $ConfigFile -MemberType NoteProperty -Name "installBehavior" -Value $Preference -Force
+        Add-Member -InputObject $ConfigFile.installBehavior.preferences -MemberType NoteProperty -Name "scope" -Value "Machine" -Force
     }
 
     $ConfigFile | ConvertTo-Json -Depth 100 | Out-File $SettingsPath -Encoding utf8 -Force


### PR DESCRIPTION
# Proposed Changes

> If users settings.json contains other things, ex.:
{
    "logging":  {
                    "level":  "verbose"
                },
    "experimentalFeatures":  {
                                 "fonts":  true,
                                 "unpackagedInstall":  true,
                                 "dependencies":  true,
                                 "restSource":  true,
                                 "directMSI":  true,
                                 "zipInstall":  true
                             },
    "$schema":  "https://aka.ms/winget-settings.schema.json"
}

This change preserves them.

