### PR TITLE
Fix TLS 1.2 negotiation in Test-ListPath.ps1

### DIFF
--- a/Sources/Winget-AutoUpdate/functions/Test-ListPath.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Test-ListPath.ps1
@@ -18,7 +18,9 @@
     Boolean: True if updated, False otherwise.
 #>
 function Test-ListPath ($ListPath, $UseWhiteList, $WingetUpdatePath) {
-
+    # Enable TLS 1.2 for secure connections
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        
     $ListType = if ($UseWhiteList) { "included_apps.txt" } else { "excluded_apps.txt" }
     $LocalList = Join-Path $WingetUpdatePath $ListType
     $dateLocal = $null


### PR DESCRIPTION
## Description

Fixes #1131

Adds explicit TLS 1.2 support to `Test-ListPath.ps1`, mirroring the existing pattern already used in `Test-ModsPath.ps1`.

## Problem

When fetching the excluded apps list from a remote URL behind a corporate proxy, the function fails with a TLS negotiation error. The root cause is that `SystemDefault` does not reliably negotiate TLS 1.2 through corporate proxies.

## Solution

Added `[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12` — the same fix already present in `Test-ModsPath.ps1`.

## Testing

Verified in a corporate proxy environment where the issue was reproduced and resolved with this change.