### PR TITLE
fix: Correctly pass value of WingetSourceCustom, Fixes #1043

### DIFF
--- a/.github/workflows/GA_Close-Inactive-Issues.yml
+++ b/.github/workflows/GA_Close-Inactive-Issues.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      contents: write
     steps:
       - uses: actions/stale@v10.1.1
         with:

--- a/.github/workflows/GA_Close-Inactive-Issues.yml
+++ b/.github/workflows/GA_Close-Inactive-Issues.yml
@@ -12,7 +12,6 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-      contents: write
     steps:
       - uses: actions/stale@v10.1.1
         with:

--- a/Sources/Winget-AutoUpdate/Winget-Install.ps1
+++ b/Sources/Winget-AutoUpdate/Winget-Install.ps1
@@ -48,7 +48,8 @@ param(
     [Parameter(Mandatory = $False)] [Switch] $Uninstall,
     [Parameter(Mandatory = $False)] [String] $LogPath,
     [Parameter(Mandatory = $False)] [Switch] $WAUWhiteList,
-    [Parameter(Mandatory = $False)] [Switch] $AllowUpgrade
+    [Parameter(Mandatory = $False)] [Switch] $AllowUpgrade,
+    [Parameter(Mandatory = $False)] [String] $Source = "winget",
 )
 
 
@@ -139,8 +140,8 @@ function Test-ModsUninstall ($AppID) {
 }
 
 #Install function
-function Install-App ($AppID, $AppArgs) {
-    $IsInstalled = Confirm-Installation $AppID -src 'winget'
+function Install-App ($AppID, $AppArgs, $Source = 'winget') {
+    $IsInstalled = Confirm-Installation $AppID -src $Source
     if (!($IsInstalled) -or $AllowUpgrade ) {
         #Check if mods exist (or already exist) for preinstall/override/custom/arguments/install/installed
         $ModsPreInstall, $ModsOverride, $ModsCustom, $ModsArguments, $ModsInstall, $ModsInstalled = Test-ModsInstall $($AppID)
@@ -170,7 +171,7 @@ function Install-App ($AppID, $AppArgs) {
             $finalArgs = if ($ModsArguments) { $ModsArguments } else { $AppArgs }
             Write-ToLog "-> Arguments (winget-level): $finalArgs" # Winget parameters with -h
             $argArray = ConvertTo-WingetArgumentArray $finalArgs
-            $WingetArgs = @("install", "--id", $AppID, "-e", "--accept-package-agreements", "--accept-source-agreements", "-s", "winget") + $argArray + @("-h")
+            $WingetArgs = @("install", "--id", $AppID, "-e", "--accept-package-agreements", "--accept-source-agreements", "-s", $Source) + $argArray + @("-h")
         }
         else {
             $WingetArgs = "install --id $AppID -e --accept-package-agreements --accept-source-agreements -s winget -h" -split " "
@@ -185,7 +186,7 @@ function Install-App ($AppID, $AppArgs) {
         }
 
         #Check if install is ok
-        $IsInstalled = Confirm-Installation $AppID -src 'winget'
+        $IsInstalled = Confirm-Installation $AppID -src $Source
         if ($IsInstalled) {
             Write-ToLog "-> $AppID successfully installed." "Green"
 
@@ -209,8 +210,8 @@ function Install-App ($AppID, $AppArgs) {
 }
 
 #Uninstall function
-function Uninstall-App ($AppID, $AppArgs) {
-    $IsInstalled = Confirm-Installation $AppID -src 'winget'
+function Uninstall-App ($AppID, $AppArgs, $Source = 'winget') {
+    $IsInstalled = Confirm-Installation $AppID -src $Source
     if ($IsInstalled) {
         #Check if mods exist (or already exist) for preuninstall/uninstall/uninstalled
         $ModsPreUninstall, $ModsUninstall, $ModsUninstalled = Test-ModsUninstall $AppID
@@ -244,7 +245,7 @@ function Uninstall-App ($AppID, $AppArgs) {
         }
 
         #Check if uninstall is ok
-        $IsInstalled = Confirm-Installation $AppID -src 'winget'
+        $IsInstalled = Confirm-Installation $AppID -src $Source
         if (!($IsInstalled)) {
             Write-ToLog "-> $AppID successfully uninstalled." "Green"
             if ($ModsUninstalled) {
@@ -399,14 +400,14 @@ if ($Winget) {
 
         #Install or Uninstall command
         if ($Uninstall) {
-            Uninstall-App $AppID $AppArgs
+            Uninstall-App $AppID $AppArgs -src $Source
         }
         else {
             #Check if app exists on Winget Repo
             $Exists = Confirm-Exist $AppID
             if ($Exists) {
                 #Install
-                Install-App $AppID $AppArgs
+                Install-App $AppID $AppArgs -src $source
             }
         }
 

--- a/Sources/Winget-AutoUpdate/Winget-Install.ps1
+++ b/Sources/Winget-AutoUpdate/Winget-Install.ps1
@@ -140,7 +140,7 @@ function Test-ModsUninstall ($AppID) {
 
 #Install function
 function Install-App ($AppID, $AppArgs) {
-    $IsInstalled = Confirm-Installation $AppID
+    $IsInstalled = Confirm-Installation $AppID -src 'winget'
     if (!($IsInstalled) -or $AllowUpgrade ) {
         #Check if mods exist (or already exist) for preinstall/override/custom/arguments/install/installed
         $ModsPreInstall, $ModsOverride, $ModsCustom, $ModsArguments, $ModsInstall, $ModsInstalled = Test-ModsInstall $($AppID)
@@ -185,7 +185,7 @@ function Install-App ($AppID, $AppArgs) {
         }
 
         #Check if install is ok
-        $IsInstalled = Confirm-Installation $AppID
+        $IsInstalled = Confirm-Installation $AppID -src 'winget'
         if ($IsInstalled) {
             Write-ToLog "-> $AppID successfully installed." "Green"
 
@@ -210,7 +210,7 @@ function Install-App ($AppID, $AppArgs) {
 
 #Uninstall function
 function Uninstall-App ($AppID, $AppArgs) {
-    $IsInstalled = Confirm-Installation $AppID
+    $IsInstalled = Confirm-Installation $AppID -src 'winget'
     if ($IsInstalled) {
         #Check if mods exist (or already exist) for preuninstall/uninstall/uninstalled
         $ModsPreUninstall, $ModsUninstall, $ModsUninstalled = Test-ModsUninstall $AppID
@@ -244,7 +244,7 @@ function Uninstall-App ($AppID, $AppArgs) {
         }
 
         #Check if uninstall is ok
-        $IsInstalled = Confirm-Installation $AppID
+        $IsInstalled = Confirm-Installation $AppID -src 'winget'
         if (!($IsInstalled)) {
             Write-ToLog "-> $AppID successfully uninstalled." "Green"
             if ($ModsUninstalled) {

--- a/Sources/Winget-AutoUpdate/Winget-Install.ps1
+++ b/Sources/Winget-AutoUpdate/Winget-Install.ps1
@@ -1,11 +1,9 @@
 <#
 .SYNOPSIS
 Install apps with Winget through Intune or SCCM.
-(Can be used standalone.) - Deprecated in favor of Winget-AutoUpdate.
 
 .DESCRIPTION
 Allow to run Winget in System Context to install your apps.
-(https://github.com/Romanitho/Winget-Install) - Deprecated in favor of Winget-AutoUpdate.
 
 .PARAMETER AppIDs
 Forward Winget App ID to install. For multiple apps, separate with ",". Case sensitive.

--- a/Sources/Winget-AutoUpdate/Winget-Install.ps1
+++ b/Sources/Winget-AutoUpdate/Winget-Install.ps1
@@ -47,7 +47,7 @@ param(
     [Parameter(Mandatory = $False)] [String] $LogPath,
     [Parameter(Mandatory = $False)] [Switch] $WAUWhiteList,
     [Parameter(Mandatory = $False)] [Switch] $AllowUpgrade,
-    [Parameter(Mandatory = $False)] [String] $Source = "winget",
+    [Parameter(Mandatory = $False)] [String] $Source = "winget"
 )
 
 
@@ -75,7 +75,7 @@ else {
 #Check if App exists in Winget Repository
 function Confirm-Exist ($AppID) {
     #Check is app exists in the winget repository
-    $WingetApp = & $winget show --Id $AppID -e --accept-source-agreements -s winget | Out-String
+    $WingetApp = & $winget show --Id $AppID -e --accept-source-agreements -s $Source | Out-String
 
     #Return if AppID exists
     if ($WingetApp -match [regex]::Escape($AppID)) {
@@ -158,11 +158,11 @@ function Install-App ($AppID, $AppArgs, $Source = 'winget') {
         Write-ToLog "-> Installing $AppID..." "DarkYellow"
         if ($ModsOverride) {
             Write-ToLog "-> Arguments (overriding default): $ModsOverride" # Without -h (user overrides default)
-            $WingetArgs = "install --id $AppID -e --accept-package-agreements --accept-source-agreements -s winget --override $ModsOverride" -split " "
+            $WingetArgs = @("install", "--id", $AppID, "-e", "--accept-package-agreements", "--accept-source-agreements", "-s", $Source, "--override", $ModsOverride)
         }
         elseif ($ModsCustom) {
             Write-ToLog "-> Arguments (customizing default): $ModsCustom" # With -h (user customizes default)
-            $WingetArgs = "install --id $AppID -e --accept-package-agreements --accept-source-agreements -s winget -h --custom $ModsCustom" -split " "
+            $WingetArgs = @("install", "--id", $AppID, "-e", "--accept-package-agreements", "--accept-source-agreements", "-s", $Source, "-h", "--custom", $ModsCustom)
         }
         elseif ($ModsArguments -or (-not [string]::IsNullOrWhiteSpace($AppArgs))) {
             # Prioritize ModsArguments from file over AppArgs from command line
@@ -172,7 +172,7 @@ function Install-App ($AppID, $AppArgs, $Source = 'winget') {
             $WingetArgs = @("install", "--id", $AppID, "-e", "--accept-package-agreements", "--accept-source-agreements", "-s", $Source) + $argArray + @("-h")
         }
         else {
-            $WingetArgs = "install --id $AppID -e --accept-package-agreements --accept-source-agreements -s winget -h" -split " "
+            $WingetArgs = @("install", "--id", $AppID, "-e", "--accept-package-agreements", "--accept-source-agreements", "-s", $Source, "-h")
         }
 
         Write-ToLog "-> Running: `"$Winget`" $WingetArgs"
@@ -398,14 +398,14 @@ if ($Winget) {
 
         #Install or Uninstall command
         if ($Uninstall) {
-            Uninstall-App $AppID $AppArgs -src $Source
+            Uninstall-App $AppID $AppArgs $Source
         }
         else {
             #Check if app exists on Winget Repo
             $Exists = Confirm-Exist $AppID
             if ($Exists) {
                 #Install
-                Install-App $AppID $AppArgs -src $source
+                Install-App $AppID $AppArgs $Source
             }
         }
 

--- a/Sources/Winget-AutoUpdate/Winget-Upgrade.ps1
+++ b/Sources/Winget-AutoUpdate/Winget-Upgrade.ps1
@@ -307,12 +307,12 @@ if (Test-Network) {
                     }
                     #if app is in "include list", update it
                     elseif ($toUpdate -contains $app.Id) {
-                        Update-App $app
+                        Update-App $app -src $Script:WingetSourceCustom
                     }
                     #if app with wildcard is in "include list", update it
                     elseif ($toUpdate | Where-Object { $app.Id -like $_ }) {
                         Write-ToLog "$($app.Name) is wildcard in the include list."
-                        Update-App $app
+                        Update-App $app -src $Script:WingetSourceCustom
                     }
                     #else, skip it
                     else {
@@ -338,7 +338,7 @@ if (Test-Network) {
                     }
                     # else, update it
                     else {
-                        Update-App $app
+                        Update-App $app -src $Script:WingetSourceCustom
                     }
                 }
             }

--- a/Sources/Winget-AutoUpdate/functions/Confirm-Installation.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Confirm-Installation.ps1
@@ -11,10 +11,10 @@
 .OUTPUTS
     Boolean: True if installed at version.
 #>
-Function Confirm-Installation ($AppName, $AppVer) {
+Function Confirm-Installation ($AppName, $AppVer, $src) {
 
     $JsonFile = "$env:TEMP\InstalledApps.json"
-    & $Winget export -s winget -o $JsonFile --include-versions | Out-Null
+    & $Winget export -s $src -o $JsonFile --include-versions | Out-Null
 
     $Packages = (Get-Content $JsonFile -Raw | ConvertFrom-Json).Sources.Packages
     $match = $Packages | Where-Object { $_.PackageIdentifier -eq $AppName -and $_.Version -like "$AppVer*" }

--- a/Sources/Winget-AutoUpdate/functions/Confirm-Installation.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Confirm-Installation.ps1
@@ -8,6 +8,10 @@
 .PARAMETER AppVer
     Expected version prefix.
 
+.PARAMETER src
+    The WinGet source to query (e.g. "winget", "msstore"). Required; passed
+    directly to `winget export -s`.
+
 .OUTPUTS
     Boolean: True if installed at version.
 #>

--- a/Sources/Winget-AutoUpdate/functions/Get-AppInfo.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Get-AppInfo.ps1
@@ -9,11 +9,14 @@
 .PARAMETER AppID
     The WinGet package identifier to query.
 
+.PARAMETER src
+    The WinGet source to query (e.g. "winget", "msstore").
+
 .OUTPUTS
     String containing the release notes URL, or empty if not found.
 
 .EXAMPLE
-    $releaseUrl = Get-AppInfo "Microsoft.PowerShell"
+    $releaseUrl = Get-AppInfo "Microsoft.PowerShell" "winget"
 
 .NOTES
     Uses WinGet show command with source agreements accepted.

--- a/Sources/Winget-AutoUpdate/functions/Get-AppInfo.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Get-AppInfo.ps1
@@ -21,8 +21,11 @@
 .NOTES
     Uses WinGet show command with source agreements accepted.
 #>
-Function Get-AppInfo ($AppID, $src) {
+Function Get-AppInfo ($AppID, $src = 'winget') {
 
+    if ([string]::IsNullOrWhiteSpace($src)) {
+        $src = 'winget'
+    }
     # Query WinGet for application details
     $String = & $winget show $AppID --accept-source-agreements -s $src | Out-String
 

--- a/Sources/Winget-AutoUpdate/functions/Get-AppInfo.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Get-AppInfo.ps1
@@ -18,10 +18,10 @@
 .NOTES
     Uses WinGet show command with source agreements accepted.
 #>
-Function Get-AppInfo ($AppID) {
+Function Get-AppInfo ($AppID, $src) {
 
     # Query WinGet for application details
-    $String = & $winget show $AppID --accept-source-agreements -s winget | Out-String
+    $String = & $winget show $AppID --accept-source-agreements -s $src | Out-String
 
     # Extract Release Notes URL using regex
     $ReleaseNote = [regex]::match($String, "(?<=Release Notes Url: )(.*)(?=\n)").Groups[0].Value

--- a/Sources/Winget-AutoUpdate/functions/Update-App.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Update-App.ps1
@@ -8,8 +8,11 @@
 
 .PARAMETER app
     PSCustomObject with Name, Id, Version, AvailableVersion properties.
+
+.PARAMETER src
+    The WinGet source to use (e.g. 'winget', 'msstore'). Defaults to 'winget'.
 #>
-Function Update-App ($app, $src) {
+Function Update-App ($app, $src = "winget") {
 
     # Helper function to build winget command parameters
     function Get-WingetParams ($Command, $ModsOverride, $ModsCustom, $ModsArguments) {

--- a/Sources/Winget-AutoUpdate/functions/Update-App.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Update-App.ps1
@@ -9,11 +9,11 @@
 .PARAMETER app
     PSCustomObject with Name, Id, Version, AvailableVersion properties.
 #>
-Function Update-App ($app) {
+Function Update-App ($app, $src) {
 
     # Helper function to build winget command parameters
     function Get-WingetParams ($Command, $ModsOverride, $ModsCustom, $ModsArguments) {
-        $params = @($Command, "--id", $app.Id, "-e", "--accept-package-agreements", "--accept-source-agreements", "-s", "winget")
+        $params = @($Command, "--id", $app.Id, "-e", "--accept-package-agreements", "--accept-source-agreements", "-s", $src)
         if ($Command -eq "install") { $params += "--force" }
 
         if ($ModsOverride) {
@@ -31,7 +31,7 @@ Function Update-App ($app) {
     }
 
     # Get release notes for notification button
-    $ReleaseNoteURL = Get-AppInfo $app.Id
+    $ReleaseNoteURL = Get-AppInfo $app.Id $src
     $Button1Text = if ($ReleaseNoteURL) { $NotifLocale.local.outputs.output[10].message } else { $null }
 
     # Send "updating" notification
@@ -64,7 +64,7 @@ Function Update-App ($app) {
         & $ModsUpgrade
     }
 
-    $ConfirmInstall = Confirm-Installation $app.Id $app.AvailableVersion
+    $ConfirmInstall = Confirm-Installation $app.Id $app.AvailableVersion $src
 
     # Fallback to install if upgrade failed
     if (-not $ConfirmInstall) {
@@ -82,7 +82,7 @@ Function Update-App ($app) {
                 & $ModsInstall
             }
 
-            $ConfirmInstall = Confirm-Installation $app.Id $app.AvailableVersion
+            $ConfirmInstall = Confirm-Installation $app.Id $app.AvailableVersion $src
         }
     }
 

--- a/Sources/Winget-AutoUpdate/mods/_Mods-Functions.ps1
+++ b/Sources/Winget-AutoUpdate/mods/_Mods-Functions.ps1
@@ -49,16 +49,16 @@ function Wait-ModsProc ($Wait) {
     Return
 }
 
-function Install-WingetID ($WingetIDInst) {
+function Install-WingetID ($WingetIDInst, $src = 'winget') {
     foreach ($app in $WingetIDInst) {
-        & $Winget install --id $app -e --accept-package-agreements --accept-source-agreements -s winget -h
+        & $Winget install --id $app -e --accept-package-agreements --accept-source-agreements -s $src -h
     }
     Return
 }
 
-function Uninstall-WingetID ($WingetIDUninst) {
+function Uninstall-WingetID ($WingetIDUninst, $src = 'winget') {
     foreach ($app in $WingetIDUninst) {
-        & $Winget uninstall --id $app -e --accept-source-agreements -s winget -h
+        & $Winget uninstall --id $app -e --accept-source-agreements -s $src -h
     }
     Return
 }
@@ -188,37 +188,37 @@ function Remove-ModsLnk ($Lnk) {
 function Add-ProgramsShortcuts ($Shortcuts, $ShortcutsTargets) {
     $programsPath = "${env:ProgramData}\Microsoft\Windows\Start Menu\Programs"
     $createdCount = 0
-    
+
     # Validate arrays match in length and are not just empty placeholders
     if ($Shortcuts.Count -ne $ShortcutsTargets.Count -or ($Shortcuts.Count -eq 1 -and [string]::IsNullOrEmpty($Shortcuts[0]))) {
         Return $createdCount
     }
-    
+
     # Create WScript.Shell COM object
     $WshShell = New-Object -ComObject WScript.Shell -ErrorAction SilentlyContinue
     if (!$WshShell) {
         Return $createdCount
     }
-    
+
     # Iterate through shortcuts
     for ($i = 0; $i -lt $Shortcuts.Count; $i++) {
         $shortcutName = $Shortcuts[$i]
         $targetPath = $ShortcutsTargets[$i]
-        
+
         # Skip empty entries
         if ([string]::IsNullOrEmpty($shortcutName) -or [string]::IsNullOrEmpty($targetPath)) {
             continue
         }
-        
+
         # Construct full shortcut path
         $shortcutPath = Join-Path $programsPath "$shortcutName.lnk"
-        
+
         # Create parent directory if it doesn't exist
         $shortcutDir = Split-Path $shortcutPath -Parent
         if (!(Test-Path $shortcutDir)) {
             New-Item -Path $shortcutDir -ItemType Directory -Force -ErrorAction SilentlyContinue | Out-Null
         }
-        
+
         # Verify target exists
         if (Test-Path $targetPath) {
             # Create shortcut
@@ -232,7 +232,7 @@ function Add-ProgramsShortcuts ($Shortcuts, $ShortcutsTargets) {
             $createdCount++
         }
     }
-    
+
     Return $createdCount
 }
 


### PR DESCRIPTION
Correctly pass value of WingetSourceCustom, to required functions and replace hardcoded -s 'winget' with -s $src

# Proposed Changes

WAU allows to set WAU_WingetSourceCustom registry key to specify what repository should WAU work with, but this key value is used only in few places, in rest it was hardcoded to 'winget' making autoupdates impossible


## Related Issues

https://github.com/Romanitho/Winget-AutoUpdate/issues/1043
