### PR TITLE
Correct VC++ Redistributable download URL

### DIFF
--- a/Sources/Winget-AutoUpdate/functions/Install-Prerequisites.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Install-Prerequisites.ps1
@@ -64,7 +64,7 @@ function Install-Prerequisites {
         if ($needsInstall) {
             try {
                 Write-ToLog "Installing VC++ Redistributable ($osArch)..."
-                $VCRedistUrl = "https://aka.ms/vs/17/release/VC_redist.$osArch.exe"
+                $VCRedistUrl = "https://aka.ms/vc14/VC_redist.$osArch.exe"
                 $installer = "$env:TEMP\VC_redist.$osArch.exe"
 
                 Invoke-WebRequest $VCRedistUrl -OutFile $installer -UseBasicParsing


### PR DESCRIPTION
# Proposed Changes

> Fix the constant updating of VC:
The URL: `https://aka.ms/vs/17/release/VC_redist.x64.exe` always deliver **v14.44.35211.0** and `$MinVersion = [version]"14.50.0.0"`

Nowadays it's a new URL as one can read in:
https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-supported-redistributable-version

Correct: `$VCRedistUrl = "https://aka.ms/vc14/VC_redist.$osArch.exe"`
