### PR TITLE
Sync main to dev : Fix immutableCreate: true on github actions

### DIFF
--- a/.github/workflows/GitFlow_Make-Release-and-Sync-to-Dev.yml
+++ b/.github/workflows/GitFlow_Make-Release-and-Sync-to-Dev.yml
@@ -120,6 +120,7 @@ jobs:
           tag: v${{ steps.release_version.outputs.NextSemVer }}
           prerelease: false  # This is a stable release
           generateReleaseNotes: true
+          immutableCreate: true
           name: WAU ${{ steps.release_version.outputs.NextSemVer }}
           artifacts: "WAU.msi,${{ steps.build_project.outputs.admx_zip_name }}"
           body: |

--- a/.github/workflows/GitFlow_Nightly-builds.yml
+++ b/.github/workflows/GitFlow_Nightly-builds.yml
@@ -236,6 +236,7 @@ jobs:
           commit: ${{ env.BRANCH }}
           prerelease: true
           generateReleaseNotes: true
+          immutableCreate: true
           name: ${{ steps.format_version.outputs.ReleaseName }}
           artifacts: "WAU.msi,${{ steps.build_project.outputs.admx_zip_name }}"
           body: |


### PR DESCRIPTION
> Bringing dev up to date with main. Even though dev has upcoming features, this merge incorporates the mandatory immutableCreate update required for the release workflow.