### PR TITLE
Refine Dutch localization strings in nl.xml

### DIFF
--- a/Sources/Winget-AutoUpdate/locale/nl.xml
+++ b/Sources/Winget-AutoUpdate/locale/nl.xml
@@ -2,57 +2,57 @@
 	<outputs>
 		<output id="0">
 			<!--Check network connection-->
-			<title>Controleer de netwerkverbinding.</title>
+			<title>Controleer de netwerkverbinding</title>
 			<!--Unable to check for software updates at this time!-->
-			<message>Er kan op dit moment niet gecontroleerd worden op software updates!</message>
+			<message>Er kan op dit moment niet op software-updates worden gecontroleerd.</message>
 		</output>
 		<output id="1">
-			<!--No internet connction-->
-			<title>Geen internetverbinding.</title>
+			<!--No internet connection-->
+			<title>Geen internetverbinding</title>
 			<!--Updates could not be verified-->
-			<message>Updates konden niet worden gecontroleerd.</message>
+			<message>Er kon niet op updates worden gecontroleerd.</message>
 		</output>
 		<output id="2">
 			<!--{App} will be updated-->
-			<title>{0} zal geüpdatet worden !</title>
+			<title>{0} wordt bijgewerkt</title>
 			<!--{v1.0} to {v2.0}-->
-			<message>{0} to {1}</message>
+			<message>{0} naar {1}</message>
 		</output>
 		<output id="3">
 			<!--{App} updated-->
-			<title>{0} is geüpdatet.</title>
+			<title>{0} is bijgewerkt</title>
 			<!--Installed version: {v1.0}-->
 			<message>Geïnstalleerde versie: {0}</message>
 		</output>
 		<output id="4">
 			<!--{App} could not be updated-->
-			<title>{0} kan niet worden geüpdatet!</title>
+			<title>{0} kon niet worden bijgewerkt</title>
 			<!--Please contact support-->
 			<message>Neem contact op met support.</message>
 		</output>
 		<output id="5">
 			<!--Logs are not available yet-->
-			<message>Logs zijn nog niet beschikbaar !</message>
+			<message>Er zijn nog geen logs beschikbaar.</message>
 		</output>
 		<output id="6">
 			<!--Starting a manual check for updated apps-->
-			<message>Start een manuele controle op software updates...</message>
+			<message>Bezig met zoeken naar software-updates...</message>
 		</output>
 		<output id="7">
 			<!--Couldn't start a manual check for updated apps-->
-			<message>Kon geen manuele controle op software updates starten!</message>
+			<message>Kon geen handmatige controle op software-updates starten.</message>
 		</output>
 		<output id="8">
-			<!--Check for updated apps already running-->
-			<message>Er wordt al naar software updates gezocht...</message>
+			<!--A check for updated apps already running-->
+			<message>Er wordt al naar software-updates gezocht...</message>
 		</output>
 		<output id="9">
 			<!--Manual check for updated apps completed-->
-			<message>Manuele controle op software updates voltooid...</message>
+			<message>Handmatige controle op software-updates voltooid.</message>
 		</output>
 		<output id="10">
 			<!--See changelog-->
-			<message>Zie changelog</message>
+			<message>Bekijk changelog</message>
 		</output>
 		<output id="11">
 			<!--Open log file-->


### PR DESCRIPTION
Updated Dutch translations for spelling and consistency improvements (nl.xml)

# Proposed Changes

**1. String 2 is untranslated.** The message body still reads `{0} to {1}`. Translated to
`{0} naar {1}`.

**2. String 4 uses the wrong tense.** "could not be updated" is past tense, but "kan niet
worden geüpdatet" means "cannot be updated". It says the update is impossible rather than
that it failed. Changed to "kon niet worden bijgewerkt".

**3. Space before the exclamation mark** (strings 2 and 5). That spacing is a French
typographic convention; in Dutch the mark attaches directly to the preceding word. Removed the spaces.

**4. "software updates" is written as two words.** English compounds are not split in Dutch.
Corrected to "software-updates" (the form "softwareupdates" is also valid).

**5. "manuele" is Belgian Dutch.** For a Netherlands audience "handmatige" is the standard
term. If this file is specifically localised for Flanders, "manuele" can stay, but it should
then be applied consistently.

**6. "bijgewerkt" instead of "geüpdatet".** Both are understood, but "bijwerken" is the term
Microsoft uses in the Dutch Windows interface, so it will feel familiar to users and matches
the surrounding OS. Applied throughout. For the same reason string 5 now uses "logs"
(matching the plural in the source) while string 11 keeps "logbestand", since the English
there is singular and the action opens one specific file.

**7. "Zie changelog" → "Bekijk changelog".** "Zie" is the wording of a cross-reference in
written text ("see appendix B"); for something the user clicks, "Bekijk" is the natural verb.
This keeps it consistent with "Open logbestand", which is unchanged.

## Related Issues

Closes #1186